### PR TITLE
+: changing the name of config, because it was causing an error.

### DIFF
--- a/Helper/General.php
+++ b/Helper/General.php
@@ -10,7 +10,7 @@ use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Config\Model\ResourceModel\Config;
+use Magento\Config\Model\ResourceModel\Config as ConfigData;
 use Magento\Config\Model\ResourceModel\Config\Data\Collection as ConfigDataCollection;
 use Magento\Config\Model\ResourceModel\Config\Data\CollectionFactory as ConfigDataCollectionFactory;
 use Magento\Framework\Module\ModuleListInterface;
@@ -81,7 +81,7 @@ class General extends AbstractHelper
         ChannableLogger $logger,
         DateTime $date,
         ConfigDataCollectionFactory $configDataCollectionFactory,
-        Config $config
+        ConfigData $config
     ) {
         $this->storeManager = $storeManager;
         $this->moduleList = $moduleList;


### PR DESCRIPTION
Magento version 2.1.9
PHP 7.0

When doing bin/magento setup:upgrade.

Im getting an error PHP Fatal error:  Cannot use Magento\Config\Model\ResourceModel\Config as Config because the name is already in use in /vagrant_data/score/httpdocs/vendor/magmodules/magento2-channable/Helper/General.php on line 13

![screen shot 2017-11-02 at 14 17 56](https://user-images.githubusercontent.com/5745279/32327970-a958a176-bfd8-11e7-9966-cbe4aa2c335a.png)
