### PR TITLE
Fix invalid class reference (typo)

### DIFF
--- a/Model/System/Config/Source/ShippingMethods.php
+++ b/Model/System/Config/Source/ShippingMethods.php
@@ -6,14 +6,14 @@
 
 namespace Magmodules\Channable\Model\System\Config\Source;
 
-use Magento\Shipping\Model\Config\Source\AllMethods;
+use Magento\Shipping\Model\Config\Source\Allmethods;
 
 /**
  * Class ShippingMethods
  *
  * @package Magmodules\Channable\Model\System\Config\Source
  */
-class ShippingMethods extends AllMethods
+class ShippingMethods extends Allmethods
 {
 
     /**


### PR DESCRIPTION
```
PHP Fatal error:  Class 'Magento\Shipping\Model\Config\Source\AllMethods' not found in /app/vendor/magmodules/magento2-channable/Model/System/Config/Source/ShippingMethods.php on line 16
```