### PR TITLE
Update Product.php

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -345,7 +345,7 @@ class Product extends AbstractHelper
     {
         $url = null;
         if ($requestPath = $product->getRequestPath()) {
-            $url = $config['base_url'] . $requestPath;
+            $url = $product->getProductUrl();
         } else {
             $url = $config['base_url'] . 'catalog/product/view/id/' . $product->getEntityId();
         }


### PR DESCRIPTION
Instead of sending url.com/product-key, send the final url that is used in the store. For conversion tracking purposes.

Because url.com/product-key get's 301 redirected to the final url if it contains categories for example.

This causes invalid conversion tracking