### PR TITLE
Added support for orders with non default currency

### DIFF
--- a/Model/Order.php
+++ b/Model/Order.php
@@ -279,6 +279,8 @@ class Order
             $this->checkoutSession->setForceBackorder($this->config->getEnableBackorders());
 
             $store = $this->storeManager->getStore($storeId);
+            $store->setCurrentCurrencyCode($data['price']['currency']);
+            
             $cartId = $this->cartManagementInterface->createEmptyCart();
             $cart = $this->cartRepositoryInterface->get($cartId)->setStore($store)->setCurrency()->setIsSuperMode(true);
             $customerId = $this->setCustomerCart($cart, $store, $data);
@@ -315,7 +317,8 @@ class Order
             }
 
             $orderId = $this->cartManagementInterface->placeOrder($cart->getId());
-
+            $store->setCurrentCurrencyCode($store->getBaseCurrencyCode());
+            
             /** @var \Magento\Sales\Model\Order $order */
             $order = $this->orderRepository->get($orderId);
             if ($this->orderHelper->getUseChannelOrderId($storeId)) {


### PR DESCRIPTION
If the Currency is allowed for the store it will be set on the order, if the store doesn't allow the currency the default is used instead. This stops needing a storeview for every currency you sell products in. After the order is placed the currency is set back to the default to stop any potential issues because of caching.