### PR TITLE
Validate if product is available instead of in stock

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -243,7 +243,7 @@ class Product extends AbstractHelper
         $filters = $config['filters'];
         if (!empty($parent)) {
             if (!empty($filters['stock'])) {
-                if (!$parent->getIsInStock()) {
+                if (!$parent->isAvailable()) {
                     return false;
                 }
             }


### PR DESCRIPTION
Configurable products which have `Manage Stock` set to `No` won't pass the validator because it's never in stock. Modified check to use `isAvailable()` instead.