### PR TITLE
Fix: unwanted fallback to original Magento product URL.

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -352,12 +352,7 @@ class Product extends AbstractHelper
      */
     public function getProductUrl($product, $simple, $config)
     {
-        $url = null;
-        if ($requestPath = $product->getRequestPath()) {
-            $url = $product->getProductUrl();
-        } else {
-            $url = $config['base_url'] . 'catalog/product/view/id/' . $product->getEntityId();
-        }
+        $url = $product->getProductUrl();
         if (!empty($config['utm_code'])) {
             if ($config['utm_code'][0] != '?') {
                 $url .= '?' . $config['utm_code'];


### PR DESCRIPTION
Some of the product URL's in our channable feed are not correct due to an unwanted fallback to an original product URL.
The code contains an assumption that the original URL must be used, if there is no request path set on the product. However, in our case this is not correct, as we have an plugin which intercepts the getProductUrl() method, and uses some logic to take the URL from somewhere else. I think it will be safe to rely on the getProductUrl() method, because looking at the code this method also contains a fallback to the original product URL:

See: magento2/vendor/magento/module-catalog/Model/Product/Url.php

`if (!empty($requestPath)) {
    $routeParams['_direct'] = $requestPath;
} else {
    $routePath = 'catalog/product/view';
    $routeParams['id'] = $product->getId();
    $routeParams['s'] = $product->getUrlKey();
    if ($categoryId) {
        $routeParams['category'] = $categoryId;
    }
}`
