### PR TITLE
Add package weight to shipping rate request

### DIFF
--- a/Model/Order.php
+++ b/Model/Order.php
@@ -460,6 +460,9 @@ class Order
         $request->setLimitCarrier('');
         $request->setBaseSubtotalInclTax($total);
         $request->setFreeShipping($shippingPriceCal <= 0);
+        if (!empty($cart->getShippingAddress()->getWeight())) {
+            $request->setPackageWeight($cart->getShippingAddress()->getWeight());
+        }
         $shipping = $this->shippingFactory->create();
         $result = $shipping->collectRates($request)->getResult();
 


### PR DESCRIPTION
I'm currently implementing the module in a store where the available shipping methods depend on the package weight. If there is no package weight set on the rate request, the wrong shipping method will be selected for the cart and the order creation will fail because the selected shipping method is not available anymore after the final shipping rates collection.

```php
//// \Magmodules\Channable\Model\Order::importOrder()
$shippingMethod = $this->getShippingMethod($cart, $store, $itemCount, $shippingPriceCal);
//// $shippingMethod is now 'tablerate_bestway' because package weight has not been set (= 0)
$shippingAddress = $cart->getShippingAddress();
$shippingAddress->setFreeShipping($shippingPriceCal <= 0); // Some carriers also check this flag.

$shippingAddress->setCollectShippingRates(true)
    ->collectShippingRates()
    ->setShippingMethod($shippingMethod);
//// After this shipping rates collection, 'tablerate_bestway' is not available anymore because
//// Magento _does_ take package weight into account
```

The solution is to set the package weight on the rate request, just like Magento does:
https://github.com/magento/magento2/blob/2.4-develop/app/code/Magento/Quote/Model/Quote/Address.php#L1045

But ... Maybe I'm overseeing something and there was a good reason to leave the package weight out in de Channable module. The only thing I can tell is that the functionality works as intended in my situation.