### PR TITLE
Replace quote in checkout session

### DIFF
--- a/Model/Order.php
+++ b/Model/Order.php
@@ -293,6 +293,8 @@ class Order
 
             $itemCount = $this->addItems->execute($cart, $data, $store, $this->lvb);
             $shippingPriceCal = $this->getShippingPrice($cart, $data, $store);
+
+            $this->checkoutSession->replaceQuote($cart);
             $cart->collectTotals();
 
             $this->checkoutSession->setChannableEnabled(1);


### PR DESCRIPTION
Carrier might need quote from checkout session. In our case the `Amasty_ShippingTableRates` needs the quote from checkout session for inventory source selection.

```php
$sourceCodes = $getSourceSelectionResultFromQuote->execute($this->quoteSession->getQuote());
```