### PR TITLE
Set reserved order id on cart

### DIFF
--- a/Model/Order.php
+++ b/Model/Order.php
@@ -319,15 +319,16 @@ class Order
                 $this->itemsForReindex->clear();
             }
 
+            if ($this->orderHelper->getUseChannelOrderId($storeId)) {
+                $newIncrementId = $this->orderHelper->getUniqueIncrementId($data['channel_id'], $storeId);
+                $cart->setReservedOrderId($newIncrementId);
+            }
+
             $orderId = $this->cartManagementInterface->placeOrder($cart->getId());
             $store->setCurrentCurrencyCode($store->getBaseCurrencyCode());
 
             /** @var \Magento\Sales\Model\Order $order */
             $order = $this->orderRepository->get($orderId);
-            if ($this->orderHelper->getUseChannelOrderId($storeId)) {
-                $newIncrementId = $this->orderHelper->getUniqueIncrementId($data['channel_id'], $storeId);
-                $order->setIncrementId($newIncrementId);
-            }
 
             if ($shippingDescription = $this->getShippingDescription($order, $data)) {
                 $order->setShippingDescription($shippingDescription);


### PR DESCRIPTION
Fixes incorrect stock reservations when using channel order id.

Order increment id is changed of order place, however the `order_placed` reservation is added before placing the order. This result in incorrect reservations which cannot be removed by the cleanup script.

**Before:**
```json
{"event_type":"shipment_created","object_type":"order","object_id":"41187","object_increment_id":"BTEST36425"}
{"event_type":"order_placed","object_type":"order","object_id":"","object_increment_id":"9000017536"}
```

**After:**
```json
{"event_type":"shipment_created","object_type":"order","object_id":"41187","object_increment_id":"BTEST36425"}
{"event_type":"order_placed","object_type":"order","object_id":"","object_increment_id":"BTEST36425"}
```