### PR TITLE
Ensure shipping cost is always a float

### DIFF
--- a/Service/Order/Shipping/CalculatePrice.php
+++ b/Service/Order/Shipping/CalculatePrice.php
@@ -53,7 +53,7 @@ class CalculatePrice
     public function execute(Quote $quote, array $orderData, StoreInterface $store): float
     {
         $taxCalculation = $this->configProvider->getNeedsTaxCalulcation('shipping', (int)$store->getId());
-        $shippingPriceCal = $orderData['price']['shipping'];
+        $shippingPriceCal = (float) $orderData['price']['shipping'];
 
         if (empty($taxCalculation)) {
             $shippingAddress = $quote->getShippingAddress();


### PR DESCRIPTION
When calculating the shipping costs, the given value from the JSON
request can also be a string, this will cause an error since the return
type is set to be a float. To ensure this will not give any issues, the
shipping costs variable is casted to a float in all cases.