### PR TITLE
Fixed if-statement to include T&T in OrderStatus calls

### DIFF
--- a/Service/Webhook/OrderStatus.php
+++ b/Service/Webhook/OrderStatus.php
@@ -79,7 +79,7 @@ class OrderStatus
             'status' => $order->getStatus()
         ];
 
-        if (!$fulfillments = $this->getFulfillment($order)) {
+        if ($fulfillments = $this->getFulfillment($order)) {
             $response['fulfillment'] = $fulfillments;
         }
 


### PR DESCRIPTION
Hi Magmodules,

I'm guessing this if-statement should've been without the !, because this way it always filters out the T&T codes from the OrderStatus call.

Tested on one of our clients and works.