### PR TITLE
Make Title Regexp field required in config

### DIFF
--- a/Block/Adminhtml/System/Config/Form/Field/ReturnLabel.php
+++ b/Block/Adminhtml/System/Config/Form/Field/ReturnLabel.php
@@ -74,4 +74,19 @@ class ReturnLabel extends AbstractFieldArray
         }
         $row->setData('option_extra_attrs', $options);
     }
+    
+     /**
+     * @param string $columnName
+     *
+     * @return string
+     * @throws \Exception
+     */
+    public function renderCellTemplate($columnName)
+    {
+        if ($columnName == 'title_regexp') {
+            $this->_columns[$columnName]['class'] = 'input-select required-entry';
+        }
+
+        return parent::renderCellTemplate($columnName);
+    }
 }


### PR DESCRIPTION
Hi Magmodules,

Currently, it's possible to save the 'Returnlabel' form in the configuration with the `magmodules_channable_order/order/return_label` setting to `Yes, use Regex` and with one line in the table, but without the `title_regexp` field filled.

This runs into trouble later, because the OrderStatus call will give this error:

```
Warning: strpos(): Empty needle in /data/web/magento2/vendor/magmodules/magento2-channable/Service
/Order/Shipping/Fulfillment.php on line 79 {"report_id":"432a3d3c087f62da1e280236bc63b7c5dedb9245e0937f0db62c610613ab2772","exception":
"[object] (Exception(code: 0): Warning: strpos(): Empty needle in /data/web/magento2/vendor/magmodules/magento2-channable/Service/Order
/Shipping/Fulfillment.php on line 79 at /data/web/magento2/vendor/magento/framework/App/ErrorHandler.php:61)"} []
```

I suppose it's also good to change the logic there to prevent this error, but making this field required in the configuration seems to be a good first step.