### PR TITLE
Save quote to cart repository

### DIFF
--- a/Service/Order/Quote/Create.php
+++ b/Service/Order/Quote/Create.php
@@ -92,6 +92,7 @@ class Create
 
         // Make sure the cart is registered by the repository
         $this->cartRepository->save($quote);
+        $quote = $this->cartRepository->get($quote->getId());
 
         return $quote;
     }

--- a/Service/Order/Quote/Create.php
+++ b/Service/Order/Quote/Create.php
@@ -15,6 +15,7 @@ use Magento\Framework\Exception\State\InputMismatchException;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteFactory;
 use Magento\Store\Api\Data\StoreInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
 
 /**
  * Create quote (guest or customer)
@@ -38,6 +39,11 @@ class Create
     private $addressHandler;
 
     /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
      * QuoteCreation constructor.
      *
      * @param QuoteFactory $quoteFactory
@@ -47,11 +53,13 @@ class Create
     public function __construct(
         QuoteFactory $quoteFactory,
         CustomerHandler $customerHandler,
-        AddressHandler $addressHandler
+        AddressHandler $addressHandler,
+        CartRepositoryInterface $cartRepository
     ) {
         $this->quoteFactory = $quoteFactory;
         $this->customerHandler = $customerHandler;
         $this->addressHandler = $addressHandler;
+        $this->cartRepository = $cartRepository;
     }
 
     /**
@@ -82,6 +90,9 @@ class Create
             $quote->setTransactionFee($orderData['price']['transaction_fee']);
         }
 
-        return $quote->save();
+        // Make sure the cart is registered by the repository
+        $this->cartRepository->save($quote);
+
+        return $quote;
     }
 }


### PR DESCRIPTION
Save the quote as soon as posible to the cart repository to make sure it will become generally available during the execution of code.

````php
$quote->save(); // does not register the quote in the repository

// ... snap
\Magento\Quote\Model\QuoteManagement::placeOrder($quote->getId());
// this will reload the quote

```

`$quote->setInventoryProcessed` is a in memory field only and the state is lost when it will be reloaded from the database