### PR TITLE
Cast mixed value to string as described for the return value

### DIFF
--- a/Model/Config/System/BaseRepository.php
+++ b/Model/Config/System/BaseRepository.php
@@ -108,7 +108,7 @@ class BaseRepository
         if (empty($storeId)) {
             $storeId = $this->getStore()->getId();
         }
-        return $this->scopeConfig->getValue($path, $scope, $storeId);
+        return (string)$this->scopeConfig->getValue($path, $scope, $storeId);
     }
 
     /**


### PR DESCRIPTION
This function returns a mixed value. In our case this caused an error on one of our projects when the module was trying to retrieve a value that was returned as an int (customer/address/street_lines to be exact)

```php
    /**
     * Retrieve config value by path and scope.
     *
     * @param string $path The path through the tree of configuration values, e.g., 'general/store_information/name'
     * @param string $scopeType The scope to use to determine config value, e.g., 'store' or 'default'
     * @param null|int|string $scopeCode
     * @return mixed
     */
    public function getValue($path, $scopeType = ScopeConfigInterface::SCOPE_TYPE_DEFAULT, $scopeCode = null);
```