### PR TITLE
A method => priority mapping is expected from getCustomShippingMethodLogic()

### DIFF
--- a/Model/Config/System/OrderRepository.php
+++ b/Model/Config/System/OrderRepository.php
@@ -38,7 +38,10 @@ class OrderRepository extends ReturnsRepository implements OrderInterface
      */
     public function getCustomShippingMethodLogic(int $storeId = null): array
     {
-        return explode(';', (string)$this->getStoreValue(self::XML_PATH_SHIPPING_CUSTOM, $storeId));
+        $shippingMethodCustom = (string)$this->getStoreValue(self::XML_PATH_SHIPPING_CUSTOM, $storeId);
+        $shippingMethodCustom = preg_replace('/\s+/', '', $shippingMethodCustom);
+        $prioritizedMethods = array_flip(array_reverse(explode(';', $shippingMethodCustom)));
+        return $prioritizedMethods;
     }
 
     /**


### PR DESCRIPTION
The custom shipping method logic doesn't work as expected: the configured custom shipping methods get ignored. 

This is because in the previous major version of the module, the configuration got returned in another form than in the current version, while usage of the result hasn't been changed.

See (current) usage at:
https://github.com/magmodules/magento2-channable/blob/bf7aaac64d9d122e99aeeeccf9fc78a0201d393a/Service/Order/Shipping/GetMethod.php#L107-L114

This logic expects [method => priority] pairs, but gets [priority => method] pairs. See:
https://github.com/magmodules/magento2-channable/blob/bf7aaac64d9d122e99aeeeccf9fc78a0201d393a/Model/Config/System/OrderRepository.php#L39-L42

In the 'previous approach', the configuration got returned differently:
https://github.com/magmodules/magento2-channable/blob/89d7bf7bc7496742c115af6c49bc8f50d8e58083/Helper/Order.php#L458-L464

I ported the old logic to the new module version.