### PR TITLE
If there are no frontend labels yet, pass an empty string, otherwise str_replace breaks on php8.1

### DIFF
--- a/Model/System/Config/Source/Attributes.php
+++ b/Model/System/Config/Source/Attributes.php
@@ -108,7 +108,7 @@ class Attributes implements ArrayInterface
      */
     public function getLabel($attribute)
     {
-        return str_replace("'", '', $attribute->getFrontendLabel());
+        return str_replace("'", '', $attribute->getFrontendLabel() ?? '');
     }
 
     /**


### PR DESCRIPTION
Currently on php8.1 the function `$attribute->getFrontendLabel()` gives null if there are no frontend labels defined.
The problem is that `str_replace()` wants the third parameter to be `array|string`. With the function returning null, this is raises the following exception: 

```
1 exception(s):
Exception #0 (Exception): Deprecated Functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in .../vendor/magmodules/magento2-channable/Model/System/Config/Source/Attributes.php on line 111
``` 

By simply checking if this is null and passing empty value into string replace we can solve the error.

```
   /**
     * @param $attribute
     *
     * @return mixed
     */
    public function getLabel($attribute)
    {
        return str_replace("'", '', $attribute->getFrontendLabel());
    }
```

to

```
   /**
     * @param $attribute
     *
     * @return mixed
     */
    public function getLabel($attribute)
    {
        return str_replace("'", '', $attribute->getFrontendLabel() ?? '');
    }
```