### PR TITLE
Override the price on all collected shipping rates

### DIFF
--- a/Service/Order/Import.php
+++ b/Service/Order/Import.php
@@ -219,6 +219,12 @@ class Import
                 ->collectShippingRates()
                 ->setShippingMethod($shippingMethod);
 
+            foreach ($shippingAddress->getShippingRatesCollection() as $rate) {
+                /** @var \Magento\Quote\Model\Quote\Address\Rate $rate */
+                $rate->setPrice($shippingPrice);
+                $rate->setCost($shippingPrice);
+            }
+
             $quote->setPaymentMethod('channable');
             $quote->setInventoryProcessed(false);
             $quote->getPayment()->importData(['method' => 'channable']);


### PR DESCRIPTION
Currently, shipping prices are only being handled for the 'Channable' shipping method. But I think the shipping amount on an imported order **must never be different** from the shipping amount specified in the Channable order data.

**The current implementation**
https://github.com/magmodules/magento2-channable/blob/996458af7b1da88b466a3dd44b6ace31f9deb65e/Service/Order/Import.php#L214

And then in the Channable shipping method:
https://github.com/magmodules/magento2-channable/blob/996458af7b1da88b466a3dd44b6ace31f9deb65e/Model/Carrier/Channable.php#L95-L112

But I think it's better to set the shipping price explicitly on **all collected rates**. I implemented this earlier in some project and at that time I couldn't find another way than to override all shipping rates after they have been collected. So that's what I did in this PR.

I _think_ that the logic already present in the Channable shipping method can be removed after merging this PR, but I'm not 100% sure because I didn't test it.