### PR TITLE
Fixes invalid dynamic bundle prices due `floatval()` with int comparison

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -934,7 +934,7 @@ class Product extends AbstractHelper
 
                 break;
             default:
-                if (floatval($product->getFinalPrice()) !== 0) {
+                if (intval($product->getFinalPrice()) !== 0) {
                     $price = $product->getPrice();
                     $finalPrice = $product->getFinalPrice();
                     $specialPrice = $product->getSpecialPrice();


### PR DESCRIPTION
Fixes dynamic bundle prices due to strict compare with a floatval(...) function and a integer.
Fixed issue https://github.com/magmodules/magento2-channable/issues/153 for me.

### Problem

Dynamic bundle prices shows an invalid price on facebook.
It uses the field `catalog_product_index_price.max_price` instead of the base price calculated with final price.

### Test.

1. Create a bundle product
2. Create 2-3 optional options
3. Run `bin/magento channable:item:update`

### Bundle data before patch

Uses invalid price on facebook 298.10 due to max price.

```
    [70466] => Array
        (
            [id] => 70466
            [title] => DHZ Overkapping Renesse Red Class Wood B400xD313cm
            [ean] => 
            [price] => 27.80
            [min_price] => 27.80
            [max_price] => 298.10
            [type_id] => bundle
            [status] => Enabled
            [visibility] => Catalog, Search
            [availability] => 1
            [manage_stock] => true
            [qty] => 
        )

```

### Bundle data after patch

Uses correct base price 1265.95 on facebook.

```
    [70466] => Array
        (
            [id] => 70466
            [title] => DHZ Overkapping Renesse Red Class Wood B400xD313cm
            [ean] => 
            [price] => 1265.95
            [min_price] => 1046.24
            [max_price] => 2783.96
            [type_id] => bundle
            [status] => Enabled
            [visibility] => Catalog, Search
            [availability] => 1
            [manage_stock] => true
            [qty] => 
        )
```