### PR TITLE
Configurable stock status (Issue: 192)

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -248,7 +248,7 @@ class Product extends AbstractHelper
         $filters = $config['filters'];
         if (!empty($parent)) {
             if (!empty($filters['stock'])) {
-                if (!$parent->getIsInStock()) {
+                if (!$this->getIsInStock($parent, $config)) {
                     return false;
                 }
             }
@@ -263,6 +263,29 @@ class Product extends AbstractHelper
         return true;
     }
 
+    /**
+     * @param \Magento\Catalog\Model\Product $parent
+     * @param                                $config
+     *
+     * @return bool
+     */
+    public function getIsInStock($parent, $config): bool
+    {
+        if (!$this->getManageStock($parent, $config)){
+            return true;
+        }
+
+        return (bool)$parent->getIsInStock();
+
+    }
+    public function getManageStock($parent, $config): bool
+    {
+        if ($parent->getUseConfigManageStock()) {
+            return (bool)$config['inventory']['config_manage_stock'];
+        }
+
+        return (bool)$parent->getManageStock();
+    }
     /**
      * @param                                $type
      * @param                                $attribute

--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -278,6 +278,13 @@ class Product extends AbstractHelper
         return (bool)$parent->getIsInStock();
 
     }
+
+    /**
+     * @param \Magento\Catalog\Model\Product $parent
+     * @param                                $config
+     *
+     * @return bool
+     */
     public function getManageStock($parent, $config): bool
     {
         if ($parent->getUseConfigManageStock()) {

--- a/Helper/Source.php
+++ b/Helper/Source.php
@@ -747,23 +747,21 @@ class Source extends AbstractHelper
         $invAtt = [];
         $enabled = $this->getStoreValue(self::XPATH_INVENTORY);
         $fields = $this->getStoreValue(self::XPATH_INVENTORY_DATA);
+        $invAtt['attributes'][] = 'is_in_stock';
+        $invAtt['attributes'][] = 'manage_stock';
+        $invAtt['attributes'][] = 'use_config_manage_stock';
+        $invAtt['config_manage_stock'] = $this->getStoreValue(self::XPATH_MANAGE_STOCK);
 
         if (!$enabled || empty($fields)) {
-            $invAtt['attributes'][] = 'is_in_stock';
+
             if ($type == 'api') {
                 $invAtt['attributes'][] = 'qty';
             }
             return $invAtt;
         }
 
-        $invAtt['attributes'] = explode(',', (string)$fields);
-        $invAtt['attributes'][] = 'is_in_stock';
+        $invAtt['attributes'] = array_merge($invAtt['attributes'], explode(',', (string)$fields));
         $invAtt['attributes'][] = 'qty';
-
-        if (in_array('manage_stock', $invAtt['attributes'])) {
-            $invAtt['attributes'][] = 'use_config_manage_stock';
-            $invAtt['config_manage_stock'] = $this->getStoreValue(self::XPATH_MANAGE_STOCK);
-        }
 
         if (in_array('qty_increments', $invAtt['attributes'])) {
             $invAtt['attributes'][] = 'use_config_qty_increments';


### PR DESCRIPTION
While checking is_in_stock value of parent product 
we should check following values ;.
mange_stock , use_config_manage_stock and store's cataloginventory/item_options/manage_stock value.

for unmanaged stocks getIsInStock should always return true, like magento does.

\Magento\CatalogInventory\Model\Stock\Item::getIsInStock
```php
public function getIsInStock()
    {
        if (!$this->getManageStock()) {
            return true;
        }
        return (bool) $this->_getData(static::IS_IN_STOCK);
    }
```