### PR TITLE
Change some methods to public to be accessible for plugins

### DIFF
--- a/Service/Order/Quote/AddressHandler.php
+++ b/Service/Order/Quote/AddressHandler.php
@@ -97,7 +97,7 @@ class AddressHandler
      * @return array
      * @throws LocalizedException
      */
-    private function getAddressData(string $type, array $orderData, Quote $quote): array
+    public function getAddressData(string $type, array $orderData, Quote $quote): array
     {
         $storeId = $quote->getStoreId();
         $customerId = $quote->getCustomerId();
@@ -198,7 +198,7 @@ class AddressHandler
      *
      * @return string
      */
-    private function getStreet(array $address, int $storeId): string
+    public function getStreet(array $address, int $storeId): string
     {
         $seperateHousenumber = $this->configProvider->seperateHousenumber((int)$storeId);
         $numberOfStreetLines = $this->configProvider->getCustomerStreetLines((int)$storeId);


### PR DESCRIPTION
There are a lot of private functions and in my opinion some of them should be public to make them accessible for plugins in Magento. In this PR case I changed just two methods because I need them to be accessible to add some changes on client level and I think they don't need to be private.