### PR TITLE
Fix Integrity constraint error

### DIFF
--- a/Service/Order/Quote/CustomerHandler.php
+++ b/Service/Order/Quote/CustomerHandler.php
@@ -76,7 +76,6 @@ class CustomerHandler
         $email = $this->cleanEmail($orderData['customer']['email']);
 
         if (!$this->configProvider->createCustomerOnImport((int)$storeId)) {
-            $quote->setCustomerId(0);
             $quote->setCustomerEmail($email);
             $quote->setCustomerFirstname($this->validateName($orderData['customer']['first_name'], 'first_name'));
             $quote->setCustomerMiddlename($this->validateName($orderData['customer']['middle_name'], 'middle_name'));


### PR DESCRIPTION
Guest customer should not be saved as `0`. This can lead to database integrity errors, as `0` is usually non-existent in `customer_entity` table.