### PR TITLE
Use referenceBlock instead of referenceContainer

### DIFF
--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -7,8 +7,8 @@
 -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
-        <referenceContainer name="order_totals">
+        <referenceBlock name="order_totals">
             <block class="Magmodules\Channable\Block\Adminhtml\Order\Totals" name="transaction_fee"/>
-        </referenceContainer>
+        </referenceBlock>
     </body>
 </page>


### PR DESCRIPTION
In some circumstances where the `order_totals` block is also modified by another module, using `referenceContainer` prevents the view from rendering due to using an incorrect reference. Using a `referenceBlock` fixes this.

See the original Magento layout for reference:
https://github.com/magento/magento2/blob/03621bbcd75cbac4ffa8266a51aa2606980f4830/app/code/Magento/Sales/view/adminhtml/layout/sales_order_view.xml#L71