### PR TITLE
(Performance) - Item Feed, improve inventory data efficiency

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -1313,4 +1313,12 @@ class Product extends AbstractHelper
 
         return array_unique($parentIds);
     }
+
+    /**
+     * @return InventoryData
+     */
+    public function getInventoryData()
+    {
+        return $this->inventoryData;
+    }
 }

--- a/Model/Generate.php
+++ b/Model/Generate.php
@@ -120,6 +120,8 @@ class Generate
             $parentRelations = $this->productHelper->getParentsFromCollection($products, $config);
             $parents = $this->productModel->getParents($parentRelations, $config);
 
+            $this->prefetchData($products->getColumnValues('sku'), $config);
+
             foreach ($products as $product) {
                 /** @var Product $product */
                 $parent = null;
@@ -207,5 +209,18 @@ class Generate
         }
 
         return null;
+    }
+
+    /**
+     * Prefetches data to reduce amount of queries required.
+     * This increases performance by a lot for environments with >1ms latency to database.
+     *
+     * @param array $skus
+     * @param array $config
+     * @return void
+     */
+    private function prefetchData(array $skus, array $config)
+    {
+        $this->productHelper->getInventoryData()->load($skus, $config);
     }
 }


### PR DESCRIPTION
Prefetching MSI inventory, as a result it doesn't have to do 2 queries per product in the feed. If the page size would be 200 products, instead of 400 queries performed, only 2 remain