### PR TITLE
Add discount info to invoice

### DIFF
--- a/Service/Order/Process/CreateInvoice.php
+++ b/Service/Order/Process/CreateInvoice.php
@@ -93,6 +93,11 @@ class CreateInvoice
             $invoice = $this->invoiceService->prepareInvoice($order);
             $invoice->setRequestedCaptureCase(Invoice::CAPTURE_OFFLINE);
             $invoice->setTransactionFee($order->getTransactionFee());
+            $invoice->setDiscountAmount($order->getDiscountAmount());
+            $invoice->setBaseDiscountAmount($order->getDiscountAmount());
+            $invoice->setDiscountDescription($order->getDiscountDescription());
+            $invoice->setGrandTotal($order->getGrandTotal());
+            $invoice->setBaseGrandTotal($order->getBaseGrandTotal());
             $invoice->register();
 
             $this->transaction->addObject($invoice);


### PR DESCRIPTION
When an invoice is created the total paid excludes the discount. This PR aims to resolve this issue by implicitly setting the discount information from the order on the invoice.