### PR TITLE
Correctly add/remove reservations from the quantity

### DIFF
--- a/Service/Product/InventoryData.php
+++ b/Service/Product/InventoryData.php
@@ -161,7 +161,7 @@ class InventoryData
         $reservations = $this->reservation[$config['inventory']['stock_id']][$product->getSku()] ?? 0;
         $sourceItems = $this->inventorySourceItems[$product->getSku()] ?? [];
 
-        $qty = isset($inventoryData['quantity']) ? $inventoryData['quantity'] - $reservations : 0;
+        $qty = isset($inventoryData['quantity']) ? $inventoryData['quantity'] + $reservations : 0;
         $isSalable = $inventoryData['is_salable'] ?? 0;
 
         return $product->setQty($qty)


### PR DESCRIPTION
Because of 
https://github.com/magmodules/magento2-channable/commit/98072e1db154fd2b70e7b11648df70e1334a3123#diff-2bb845804f110f1d15dfdd942602e6d8c5d3a9e92d104f8acb1b2e8153ee146dL102
https://github.com/magmodules/magento2-channable/commit/98072e1db154fd2b70e7b11648df70e1334a3123#diff-2bb845804f110f1d15dfdd942602e6d8c5d3a9e92d104f8acb1b2e8153ee146dR115

the negative reservations actually get ADDED to the current quantity.
Let's say a product has a stock of 3, 1 is placed in reservation.
Thus the salable stock is 2, but channable says the salable stock is 4 now.

This change ensures it is removed again