### PR TITLE
Do not overwrite previously generated value

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -217,7 +217,8 @@ class Product extends AbstractHelper
                 $value = $this->getCondition(
                     $attribute['condition'],
                     $productData,
-                    $attribute
+                    $attribute,
+                    $value
                 );
             }
 
@@ -900,10 +901,10 @@ class Product extends AbstractHelper
      *
      * @return string
      */
-    public function getCondition($conditions, $product, $attribute)
+    public function getCondition($conditions, $product, $attribute, $value = null)
     {
         $data = null;
-        $value = $product->getData($attribute['source']);
+        $value = $value ?? $product->getData($attribute['source']);
         if ($attribute['source'] == 'is_in_stock') {
             $value = $this->getAvailability($product);
         }


### PR DESCRIPTION
This PR fixes an issue where a value that was generated previously will always be overwritten by the `getCondition` method because it retrieves the data directly from the product.

For example, when the `manage_stock` attribute is selected it will use `getAttributeValue` and `getManageStockValue` to retrieve the correct value. But when `use_config_manage_stock` is enabled on a product it should not listen to the product's value, which is what `getManageStockValue` does.
But because `Helper/Source.php:632` defines conditions for `manage_stock` the `getCondition` will run which retrieves the value directly from the product and not the default configuration.

This can be reproduced by setting `manage_stock` to `false` and `use_config_manage_stock` to true on a product and `true` in the global configuration. 

As I am not completely familiar with this module I am unsure what the impact is of this change and if this is the best solution.