### PR TITLE
Remove CSP headers from frontend responses

### DIFF
--- a/Observer/Controller/RemoveCsp.php
+++ b/Observer/Controller/RemoveCsp.php
@@ -31,7 +31,7 @@ class RemoveCsp implements ObserverInterface
         if (!$response || !$request) {
             return;
         }
-        /** @todo When php7 support is dropped replace 'str_starts_with($request->getFullActionName(), 'channable_')' */
+        /** @todo When php7 support is dropped replace with: 'str_starts_with($request->getFullActionName(), 'channable_')' */
         if (strpos($request->getFullActionName(), 'channable_') === 0) {
             $response->clearHeader('content-security-policy-report-only')
                 ->clearHeader('Content-Security-Policy-Report-Only')

--- a/Observer/Controller/RemoveCsp.php
+++ b/Observer/Controller/RemoveCsp.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright © 2019 Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magmodules\Channable\Observer\Controller;
+
+use Magento\Framework\App\Request\Http as RequestHttp;
+use Magento\Framework\App\Response\Http as ResponseHttp;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+
+/**
+ * Class RemoveCsp
+ *
+ * @package Magmodules\Channable\Observer\Controller
+ */
+class RemoveCsp implements ObserverInterface
+{
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var ResponseHttp $response */
+        $response = $observer->getEvent()->getData('response');
+        /** @var RequestHttp $request */
+        $request = $observer->getEvent()->getData('request');
+        if (!$response || !$request) {
+            return;
+        }
+        /** @todo When php7 support is dropped replace 'str_starts_with($request->getFullActionName(), 'channable_')' */
+        if (strpos($request->getFullActionName(), 'channable_') === 0) {
+            $response->clearHeader('content-security-policy-report-only')
+                ->clearHeader('Content-Security-Policy-Report-Only')
+                ->clearHeader('Content-Security-Policy');
+        }
+    }
+}

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -10,4 +10,7 @@
     <event name="salesrule_validator_process">
         <observer name="salesrule_validator_process" instance="Magmodules\Channable\Observer\SalesRule\ValidatorProcess" shared="false"/>
     </event>
+    <event name="controller_front_send_response_before">
+        <observer name="channable_controller_front_remove_csp" instance="Magmodules\Channable\Observer\Controller\RemoveCsp"/>
+    </event>
 </config>


### PR DESCRIPTION
# Problem
When Magento returns a large `content-security-policy` for Channable controllers Channable returns the following in the Channable app:

> Got more than 8190 bytes (8212) when reading Header value is too long.

# Resolution
Removing CSP headers for all Channable controllers. This solution is inspired by the [Adyen Magento module solution]( https://github.com/Adyen/adyen-magento2/commit/28e804b7c2e6e823fbbc6b1224f7552a38a68ede).