### PR TITLE
Fix errors caused by product data being array

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -357,7 +357,7 @@ class Product extends AbstractHelper
             if ((!empty($attribute['actions']) || !empty($attribute['max'])) && !is_array($value)) {
                 $value = $this->getFormat($value, $attribute, $config, $product);
             }
-            if (!empty($attribute['suffix'])) {
+            if (!empty($attribute['suffix']) && is_string($value)) {
                 if (!empty($config[$attribute['suffix']])) {
                     $value .= $config[$attribute['suffix']];
                 }
@@ -745,14 +745,20 @@ class Product extends AbstractHelper
      * @param $attribute
      * @param \Magento\Catalog\Model\Product $product
      *
-     * @return string
+     * @return string|array
      */
     public function getValue($attribute, $product)
     {
         try {
             $source = isset($attribute['source']) ? $attribute['source'] : '';
             $type = isset($attribute['type']) ? $attribute['type'] : '';
-            $value = (string)$product->getData($source);
+            $value = $product->getData($source);
+
+            if (is_array($value)) {
+                return $value;
+            }
+
+            $value = (string)$value;
 
             if ($type === 'media_image' && $value) {
                 return $this->catalogProductMediaConfig->getMediaUrl($value);


### PR DESCRIPTION
Before, we cast any product data we get to string.
This causes problems when using data that does not return a string. Like `media_gallery`

With this change we pass through the value if it is an array in the same way as we used to before 
https://github.com/magmodules/magento2-channable/commit/85157da192a2cb22e5c08abfe295f0db5a200b5f#diff-a3e4cad992660319812edf6a3e7db41926ab4e8ac8f4fb29de36541097bd3000R755

forced it to a string.