### PR TITLE
Fix AddressHandler sanitize function to accept int

### DIFF
--- a/Service/Order/Quote/AddressHandler.php
+++ b/Service/Order/Quote/AddressHandler.php
@@ -143,7 +143,7 @@ class AddressHandler
      *
      * @return string|null Sanitized string or null if empty
      */
-    private function sanitize(?string $value, string $pattern, ?int $maxLength = null): ?string
+    private function sanitize(null|string|int $value, string $pattern, ?int $maxLength = null): ?string
     {
         $value = (string) $value;
 


### PR DESCRIPTION
In my magento installation house_number is a int value (checked and transformed in int by a external module). So I need the sanitize function to accept the int.

`main.CRITICAL: TypeError: Magmodules\Channable\Service\Order\Quote\AddressHandler::sanitize(): Argument #1 ($value) must be of type ?string, int given, called in /vendor/magmodules/magento2-channable/Service/Order/Quote/AddressHandler.php on line 249 and defined in /vendor/magmodules/magento2-channable/Service/Order/Quote/AddressHandler.php:146`