### PR TITLE
Fix for upcoming PHP 8.5 deprecation, casting to boolean should use 'bool' type

### DIFF
--- a/Console/Command/OrderSimulate.php
+++ b/Console/Command/OrderSimulate.php
@@ -154,7 +154,7 @@ class OrderSimulate extends Command
         }
 
         if ($lvb = $input->getOption(self::INPUT_KEY_LVB)) {
-            $options['lvb'] = (boolean)$lvb;
+            $options['lvb'] = (bool)$lvb;
         }
 
         if ($country = $input->getOption(self::INPUT_KEY_COUNTRY_CODE)) {

--- a/Helper/General.php
+++ b/Helper/General.php
@@ -223,7 +223,7 @@ class General extends AbstractHelper
      */
     private function isSerialized($value)
     {
-        return (boolean)preg_match('/^((s|i|d|b|a|O|C):|N;)/', $value);
+        return (bool)preg_match('/^((s|i|d|b|a|O|C):|N;)/', $value);
     }
 
     /**


### PR DESCRIPTION
See https://php.watch/versions/8.5/boolean-double-integer-binary-casts-deprecated