### PR TITLE
use max/min price from product price object

### DIFF
--- a/Service/Product/PriceData.php
+++ b/Service/Product/PriceData.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magmodules\Channable\Service\Product;
 
+use Magento\Bundle\Model\Product\Price;
 use Magento\Catalog\Helper\Data as CatalogHelper;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product\CatalogPrice;
@@ -45,7 +46,7 @@ class PriceData
      * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      */
-    public function execute(array $config, Product$product): array
+    public function execute(array $config, Product $product): array
     {
         switch ($product->getTypeId()) {
             case 'configurable':
@@ -90,6 +91,10 @@ class PriceData
                 break;
             case 'bundle':
                 $price = $product->getPrice();
+                if ((int)$product->getPriceType() === Price::PRICE_TYPE_DYNAMIC) {
+                    $product['min_price'] = $product->getPriceInfo()->getPrice('final_price')->getMinimalPrice()->getBaseAmount();
+                    $product['max_price'] = $product->getPriceInfo()->getPrice('final_price')->getMaximalPrice()->getBaseAmount();
+                }
                 $finalPrice = $product->getFinalPrice();
                 $specialPrice = $product->getSpecialPrice();
                 $rulePrice = $this->ruleFactory->create()->getRulePrice(


### PR DESCRIPTION
I also came across this bug: https://github.com/magmodules/magento2-channable/issues/201. While it can be considered a Magento bug, I think it’s better to use the price model to get the min/max price. This does not check for out-of-stock products and simply returns prices based on the bundle options. 

The reason I think this is better is that you don’t want sales channels to show an incorrect price, even if a child item is out of stock and therefore the entire bundle is out of stock.

I added an extra check for dynamic pricing, since that’s the only case where the min/max price is relevant.