### PR TITLE
Fix return matching when GTIN is null by falling back to item.id

### DIFF
--- a/Service/Returns/CreateCreditmemo.php
+++ b/Service/Returns/CreateCreditmemo.php
@@ -58,11 +58,14 @@ class CreateCreditmemo
         }
 
         $item = $return->getItem();
-        if (!isset($item['gtin'])) {
-            throw new InputException(__('GTIN is missing in return item data.'));
+        $gtin = $item['gtin'] ?? null;
+        $productId = isset($item['id']) && is_numeric($item['id']) ? (int)$item['id'] : null;
+
+        if ($gtin === null && $productId === null) {
+            throw new InputException(__('GTIN and product ID are both missing in return item data.'));
         }
 
-        if (!$sku = $this->getSkuFromGtin->execute($item['gtin'], (int)$return->getStoreId())) {
+        if (!$sku = $this->getSkuFromGtin->execute($gtin, (int)$return->getStoreId(), $productId)) {
             throw new InputException(__('Unable to find SKU for GTIN.'));
         }
 

--- a/Service/Returns/GetByOrder.php
+++ b/Service/Returns/GetByOrder.php
@@ -74,15 +74,17 @@ class GetByOrder
      */
     private function getSkuFromReturnData($itemData, int $storeId): ?string
     {
-        if (is_array($itemData)) {
-            return $this->getSkuFromGtin->execute($itemData['gtin'] ?? null, $storeId);
+        if (!is_array($itemData)) {
+            try {
+                $itemData = $this->json->unserialize($itemData);
+            } catch (\Exception $exception) {
+                return null;
+            }
         }
 
-        try {
-            $itemData = $this->json->unserialize($itemData);
-            return $this->getSkuFromGtin->execute($itemData['gtin'] ?? null, $storeId);
-        } catch (\Exception $exception) {
-            return null;
-        }
+        $gtin = $itemData['gtin'] ?? null;
+        $productId = isset($itemData['id']) && is_numeric($itemData['id']) ? (int)$itemData['id'] : null;
+
+        return $this->getSkuFromGtin->execute($gtin, $storeId, $productId);
     }
 }

--- a/Service/Returns/GetSkuFromGtin.php
+++ b/Service/Returns/GetSkuFromGtin.php
@@ -42,12 +42,18 @@ class GetSkuFromGtin
     /**
      * @param string|null $gtin
      * @param int $storeId
+     * @param int|null $productId Fallback product entity ID (item.id from Channable)
      * @return string|null
      */
-    public function execute(?string $gtin, int $storeId): ?string
+    public function execute(?string $gtin, int $storeId, ?int $productId = null): ?string
     {
         $gtinAttribute = $this->getGtinAttributeCode($storeId);
-        if ($gtinAttribute == 'sku' || $gtinAttribute == null || $gtin == null) {
+
+        if ($gtin === null) {
+            return $this->resolveByProductId($productId, $storeId);
+        }
+
+        if ($gtinAttribute == 'sku' || $gtinAttribute == null) {
             return $gtin;
         }
 
@@ -74,11 +80,17 @@ class GetSkuFromGtin
             // Fallback: If no match found and GTIN is numeric, try loading by entity ID
             // This handles cases where channels (like Amazon) use Product ID instead of actual GTIN
             if (is_numeric($gtin)) {
-                try {
-                    $productById = $this->productRepository->getById((int)$gtin, false, $storeId);
-                    return $productById->getSku();
-                } catch (NoSuchEntityException $e) {
-                    // Product not found by ID, return null
+                $sku = $this->resolveByProductId((int)$gtin, $storeId);
+                if ($sku) {
+                    return $sku;
+                }
+            }
+
+            // Fallback: try item.id (Magento Product ID) when GTIN-based matching fails
+            if ($productId) {
+                $sku = $this->resolveByProductId($productId, $storeId);
+                if ($sku) {
+                    return $sku;
                 }
             }
         } catch (\Exception $exception) {
@@ -86,6 +98,25 @@ class GetSkuFromGtin
         }
 
         return null;
+    }
+
+    /**
+     * @param int|null $productId
+     * @param int $storeId
+     * @return string|null
+     */
+    private function resolveByProductId(?int $productId, int $storeId): ?string
+    {
+        if (!$productId) {
+            return null;
+        }
+
+        try {
+            $product = $this->productRepository->getById($productId, false, $storeId);
+            return $product->getSku();
+        } catch (NoSuchEntityException $e) {
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
Marketplaces like Decathlon (Mirakl) do not include a GTIN in return payloads. The module now falls back to item.id (Magento Product ID) when GTIN is null or when GTIN-based matching fails.