### PR TITLE
Exclude external-video thumbnails from feed image gallery

### DIFF
--- a/Helper/Product.php
+++ b/Helper/Product.php
@@ -527,6 +527,9 @@ class Product extends AbstractHelper
             }
 
             foreach ($galleryImages as $image) {
+                if (!empty($image['media_type']) && $image['media_type'] === 'external-video') {
+                    continue;
+                }
                 if (empty($image['disabled']) || !empty($config['inc_hidden_image'])) {
                     $images[] = $this->catalogProductMediaConfig->getMediaUrl($image['file']);
                 }


### PR DESCRIPTION
Video thumbnails (media_type 'external-video') are small placeholder images not suitable as product images. Skip them in the gallery loop.