### PR TITLE
Add REST API endpoints for Channable orders and returns

### DIFF
--- a/Api/Order/Data/SearchResultsInterface.php
+++ b/Api/Order/Data/SearchResultsInterface.php
@@ -20,14 +20,14 @@ interface SearchResultsInterface extends FrameworkSearchResultsInterface
     /**
      * Gets Code Items.
      *
-     * @return ChannableOrderData[]
+     * @return \Magmodules\Channable\Api\Order\Data\DataInterface[]
      */
     public function getItems(): array;
 
     /**
      * Sets Code Items.
      *
-     * @param ChannableOrderData[] $items
+     * @param \Magmodules\Channable\Api\Order\Data\DataInterface[] $items
      * @return $this
      */
     public function setItems(array $items): self;

--- a/Api/Order/ItemInterface.php
+++ b/Api/Order/ItemInterface.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Api\Order;
+
+/**
+ * Flat DTO for a single Channable order record (API-safe).
+ *
+ * @api
+ */
+interface ItemInterface
+{
+    /**
+     * @return int
+     */
+    public function getEntityId(): int;
+
+    /**
+     * @return int
+     */
+    public function getChannableId(): int;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelId(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelName(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelLabel(): ?string;
+
+    /**
+     * @return int|null
+     */
+    public function getMagentoOrderId(): ?int;
+
+    /**
+     * @return string|null
+     */
+    public function getMagentoIncrementId(): ?string;
+
+    /**
+     * @return int
+     */
+    public function getStoreId(): int;
+
+    /**
+     * @return string|null
+     */
+    public function getStatus(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannableOrderStatus(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getCreatedAt(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatedAt(): ?string;
+}

--- a/Api/Order/SearchInterface.php
+++ b/Api/Order/SearchInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Api\Order;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+/**
+ * REST API interface for searching Channable orders.
+ *
+ * @api
+ */
+interface SearchInterface
+{
+    /**
+     * Search Channable orders by criteria.
+     *
+     * Returns a flat list of order records with channel identifiers
+     * and linked Magento order references.
+     *
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \Magmodules\Channable\Api\Order\SearchResultInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultInterface;
+}

--- a/Api/Order/SearchResultInterface.php
+++ b/Api/Order/SearchResultInterface.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Api\Order;
+
+/**
+ * Search result for Channable orders API.
+ *
+ * @api
+ */
+interface SearchResultInterface
+{
+    /**
+     * @return \Magmodules\Channable\Api\Order\ItemInterface[]
+     */
+    public function getItems(): array;
+
+    /**
+     * @param \Magmodules\Channable\Api\Order\ItemInterface[] $items
+     * @return $this
+     */
+    public function setItems(array $items): self;
+
+    /**
+     * @return int
+     */
+    public function getTotalCount(): int;
+
+    /**
+     * @param int $totalCount
+     * @return $this
+     */
+    public function setTotalCount(int $totalCount): self;
+
+    /**
+     * @return \Magento\Framework\Api\SearchCriteriaInterface
+     */
+    public function getSearchCriteria(): \Magento\Framework\Api\SearchCriteriaInterface;
+
+    /**
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return $this
+     */
+    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria): self;
+}

--- a/Api/Returns/Data/SearchResultsInterface.php
+++ b/Api/Returns/Data/SearchResultsInterface.php
@@ -20,14 +20,14 @@ interface SearchResultsInterface extends FrameworkSearchResultsInterface
     /**
      * Gets Code Items.
      *
-     * @return ChannableReturnsData[]
+     * @return \Magmodules\Channable\Api\Returns\Data\DataInterface[]
      */
     public function getItems(): array;
 
     /**
      * Sets Code Items.
      *
-     * @param ChannableReturnsData[] $items
+     * @param \Magmodules\Channable\Api\Returns\Data\DataInterface[] $items
      *
      * @return $this
      */

--- a/Api/Returns/ItemInterface.php
+++ b/Api/Returns/ItemInterface.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Api\Returns;
+
+/**
+ * Flat DTO for a single Channable return record (API-safe).
+ *
+ * @api
+ */
+interface ItemInterface
+{
+    /**
+     * @return int
+     */
+    public function getEntityId(): int;
+
+    /**
+     * @return int
+     */
+    public function getChannableId(): int;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelId(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelName(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelReturnId(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelOrderId(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getChannelOrderIdInternal(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getPlatformOrderId(): ?string;
+
+    /**
+     * @return int|null
+     */
+    public function getMagentoOrderId(): ?int;
+
+    /**
+     * @return string|null
+     */
+    public function getMagentoIncrementId(): ?string;
+
+    /**
+     * @return int|null
+     */
+    public function getMagentoCreditmemoId(): ?int;
+
+    /**
+     * @return string|null
+     */
+    public function getMagentoCreditmemoIncrementId(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getCustomerName(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getReason(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getComment(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getStatus(): ?string;
+
+    /**
+     * @return int
+     */
+    public function getStoreId(): int;
+
+    /**
+     * @return string|null
+     */
+    public function getCreatedAt(): ?string;
+
+    /**
+     * @return string|null
+     */
+    public function getUpdatedAt(): ?string;
+}

--- a/Api/Returns/SearchInterface.php
+++ b/Api/Returns/SearchInterface.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Api\Returns;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+
+/**
+ * REST API interface for searching Channable returns.
+ *
+ * @api
+ */
+interface SearchInterface
+{
+    /**
+     * Search Channable returns by criteria.
+     *
+     * Returns a flat list of return records with channel identifiers
+     * and linked Magento order/creditmemo references.
+     *
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return \Magmodules\Channable\Api\Returns\SearchResultInterface
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultInterface;
+}

--- a/Api/Returns/SearchResultInterface.php
+++ b/Api/Returns/SearchResultInterface.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Api\Returns;
+
+/**
+ * Search result for Channable returns API.
+ *
+ * @api
+ */
+interface SearchResultInterface
+{
+    /**
+     * @return \Magmodules\Channable\Api\Returns\ItemInterface[]
+     */
+    public function getItems(): array;
+
+    /**
+     * @param \Magmodules\Channable\Api\Returns\ItemInterface[] $items
+     * @return $this
+     */
+    public function setItems(array $items): self;
+
+    /**
+     * @return int
+     */
+    public function getTotalCount(): int;
+
+    /**
+     * @param int $totalCount
+     * @return $this
+     */
+    public function setTotalCount(int $totalCount): self;
+
+    /**
+     * @return \Magento\Framework\Api\SearchCriteriaInterface
+     */
+    public function getSearchCriteria(): \Magento\Framework\Api\SearchCriteriaInterface;
+
+    /**
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
+     * @return $this
+     */
+    public function setSearchCriteria(\Magento\Framework\Api\SearchCriteriaInterface $searchCriteria): self;
+}

--- a/Model/Api/OrderItem.php
+++ b/Model/Api/OrderItem.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Model\Api;
+
+use Magento\Framework\DataObject;
+use Magmodules\Channable\Api\Order\ItemInterface;
+
+class OrderItem extends DataObject implements ItemInterface
+{
+    public function getEntityId(): int
+    {
+        return (int) $this->getData('entity_id');
+    }
+
+    public function getChannableId(): int
+    {
+        return (int) $this->getData('channable_id');
+    }
+
+    public function getChannelId(): ?string
+    {
+        return $this->getData('channel_id');
+    }
+
+    public function getChannelName(): ?string
+    {
+        return $this->getData('channel_name');
+    }
+
+    public function getChannelLabel(): ?string
+    {
+        return $this->getData('channel_label');
+    }
+
+    public function getMagentoOrderId(): ?int
+    {
+        $val = $this->getData('magento_order_id');
+        return $val !== null ? (int) $val : null;
+    }
+
+    public function getMagentoIncrementId(): ?string
+    {
+        return $this->getData('magento_increment_id');
+    }
+
+    public function getStoreId(): int
+    {
+        return (int) $this->getData('store_id');
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->getData('status');
+    }
+
+    public function getChannableOrderStatus(): ?string
+    {
+        return $this->getData('channable_order_status');
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->getData('created_at');
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->getData('updated_at');
+    }
+}

--- a/Model/Api/OrderSearch.php
+++ b/Model/Api/OrderSearch.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Model\Api;
+
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magmodules\Channable\Api\Order\SearchInterface;
+use Magmodules\Channable\Api\Order\SearchResultInterface;
+use Magmodules\Channable\Model\Order\ResourceModel\CollectionFactory;
+
+class OrderSearch implements SearchInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
+
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        CollectionProcessorInterface $collectionProcessor
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->collectionProcessor = $collectionProcessor;
+    }
+
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultInterface
+    {
+        $collection = $this->collectionFactory->create();
+        $this->collectionProcessor->process($searchCriteria, $collection);
+
+        $items = [];
+        foreach ($collection as $model) {
+            $items[] = new OrderItem($model->getData());
+        }
+
+        $result = new SearchResult();
+        $result->setItems($items);
+        $result->setTotalCount($collection->getSize());
+        $result->setSearchCriteria($searchCriteria);
+
+        return $result;
+    }
+}

--- a/Model/Api/ReturnItem.php
+++ b/Model/Api/ReturnItem.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Model\Api;
+
+use Magento\Framework\DataObject;
+use Magmodules\Channable\Api\Returns\ItemInterface;
+
+class ReturnItem extends DataObject implements ItemInterface
+{
+    public function getEntityId(): int
+    {
+        return (int) $this->getData('entity_id');
+    }
+
+    public function getChannableId(): int
+    {
+        return (int) $this->getData('channable_id');
+    }
+
+    public function getChannelId(): ?string
+    {
+        return $this->getData('channel_id');
+    }
+
+    public function getChannelName(): ?string
+    {
+        return $this->getData('channel_name');
+    }
+
+    public function getChannelReturnId(): ?string
+    {
+        return $this->getData('channel_return_id');
+    }
+
+    public function getChannelOrderId(): ?string
+    {
+        return $this->getData('channel_order_id');
+    }
+
+    public function getChannelOrderIdInternal(): ?string
+    {
+        return $this->getData('channel_order_id_internal');
+    }
+
+    public function getPlatformOrderId(): ?string
+    {
+        return $this->getData('platform_order_id');
+    }
+
+    public function getMagentoOrderId(): ?int
+    {
+        $val = $this->getData('magento_order_id');
+        return $val !== null ? (int) $val : null;
+    }
+
+    public function getMagentoIncrementId(): ?string
+    {
+        return $this->getData('magento_increment_id');
+    }
+
+    public function getMagentoCreditmemoId(): ?int
+    {
+        $val = $this->getData('magento_creditmemo_id');
+        return $val !== null ? (int) $val : null;
+    }
+
+    public function getMagentoCreditmemoIncrementId(): ?string
+    {
+        return $this->getData('magento_creditmemo_increment_id');
+    }
+
+    public function getCustomerName(): ?string
+    {
+        return $this->getData('customer_name');
+    }
+
+    public function getReason(): ?string
+    {
+        return $this->getData('reason');
+    }
+
+    public function getComment(): ?string
+    {
+        return $this->getData('comment');
+    }
+
+    public function getStatus(): ?string
+    {
+        return $this->getData('status');
+    }
+
+    public function getStoreId(): int
+    {
+        return (int) $this->getData('store_id');
+    }
+
+    public function getCreatedAt(): ?string
+    {
+        return $this->getData('created_at');
+    }
+
+    public function getUpdatedAt(): ?string
+    {
+        return $this->getData('updated_at');
+    }
+}

--- a/Model/Api/ReturnsSearch.php
+++ b/Model/Api/ReturnsSearch.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Model\Api;
+
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magmodules\Channable\Api\Returns\SearchInterface;
+use Magmodules\Channable\Api\Returns\SearchResultInterface;
+use Magmodules\Channable\Model\Returns\CollectionFactory;
+
+class ReturnsSearch implements SearchInterface
+{
+    /**
+     * @var CollectionFactory
+     */
+    private $collectionFactory;
+
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
+
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        CollectionProcessorInterface $collectionProcessor
+    ) {
+        $this->collectionFactory = $collectionFactory;
+        $this->collectionProcessor = $collectionProcessor;
+    }
+
+    public function getList(SearchCriteriaInterface $searchCriteria): SearchResultInterface
+    {
+        $collection = $this->collectionFactory->create();
+        $this->collectionProcessor->process($searchCriteria, $collection);
+
+        $items = [];
+        foreach ($collection as $model) {
+            $items[] = new ReturnItem($model->getData());
+        }
+
+        $result = new SearchResult();
+        $result->setItems($items);
+        $result->setTotalCount($collection->getSize());
+        $result->setSearchCriteria($searchCriteria);
+
+        return $result;
+    }
+}

--- a/Model/Api/SearchResult.php
+++ b/Model/Api/SearchResult.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magmodules\Channable\Model\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\DataObject;
+
+class SearchResult extends DataObject implements
+    \Magmodules\Channable\Api\Order\SearchResultInterface,
+    \Magmodules\Channable\Api\Returns\SearchResultInterface
+{
+    public function getItems(): array
+    {
+        return $this->getData('items') ?? [];
+    }
+
+    public function setItems(array $items): self
+    {
+        return $this->setData('items', $items);
+    }
+
+    public function getTotalCount(): int
+    {
+        return (int) $this->getData('total_count');
+    }
+
+    public function setTotalCount(int $totalCount): self
+    {
+        return $this->setData('total_count', $totalCount);
+    }
+
+    public function getSearchCriteria(): SearchCriteriaInterface
+    {
+        return $this->getData('search_criteria');
+    }
+
+    public function setSearchCriteria(SearchCriteriaInterface $searchCriteria): self
+    {
+        return $this->setData('search_criteria', $searchCriteria);
+    }
+}

--- a/Model/Order/Repository.php
+++ b/Model/Order/Repository.php
@@ -95,7 +95,6 @@ class Repository implements ChannableOrderRepository
     public function getList($criteria)
     {
         $collection = $this->channableOrderCollectionFactory->create();
-        $this->extensionAttributesJoinProcessor->process($collection, self::DATA_INTERFACE);
         $this->collectionProcessor->process($criteria, $collection);
         $searchResults = $this->channableOrderSearchResultsFactory->create();
         $searchResults->setSearchCriteria($criteria);

--- a/Model/Returns/Repository.php
+++ b/Model/Returns/Repository.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Magmodules\Channable\Model\Returns;
 
+use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Exception\CouldNotDeleteException;
 use Magento\Framework\Exception\CouldNotSaveException;
@@ -40,6 +41,10 @@ class Repository implements RepositoryInterface
      * @var DataInterfaceFactory
      */
     private $dataFactory;
+    /**
+     * @var CollectionProcessorInterface
+     */
+    private $collectionProcessor;
 
     /**
      * Repository constructor.
@@ -48,17 +53,20 @@ class Repository implements RepositoryInterface
      * @param CollectionFactory $collectionFactory
      * @param ResourceModel $resource
      * @param DataInterfaceFactory $dataFactory
+     * @param CollectionProcessorInterface $collectionProcessor
      */
     public function __construct(
         SearchResultsInterfaceFactory $searchResultFactory,
         CollectionFactory $collectionFactory,
         ResourceModel $resource,
-        DataInterfaceFactory $dataFactory
+        DataInterfaceFactory $dataFactory,
+        CollectionProcessorInterface $collectionProcessor
     ) {
         $this->searchResultFactory = $searchResultFactory;
         $this->collectionFactory = $collectionFactory;
         $this->resource = $resource;
         $this->dataFactory = $dataFactory;
+        $this->collectionProcessor = $collectionProcessor;
     }
 
     /**
@@ -67,6 +75,7 @@ class Repository implements RepositoryInterface
     public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface
     {
         $collection = $this->collectionFactory->create();
+        $this->collectionProcessor->process($searchCriteria, $collection);
         return $this->searchResultFactory->create()
             ->setSearchCriteria($searchCriteria)
             ->setItems($collection->getItems())

--- a/Test/End-2-end/support/services/BaseApi.ts
+++ b/Test/End-2-end/support/services/BaseApi.ts
@@ -91,6 +91,23 @@ export default class BaseApi {
   }
 
   /**
+   * Call a Magento REST API endpoint with admin Bearer auth.
+   */
+  async restGet(baseURL: string, path: string): Promise<{ status: number; body: any }> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/V1${path}`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+      },
+    });
+    const body = await response.json();
+    return { status: response.status, body };
+  }
+
+  /**
    * Run a PHP snippet inside the container (for custom queries).
    */
   protected execInContainer(phpCode: string): string {

--- a/Test/End-2-end/support/services/ChannableApi.ts
+++ b/Test/End-2-end/support/services/ChannableApi.ts
@@ -64,6 +64,79 @@ export default class ChannableApi extends BaseApi {
   }
 
   /**
+   * POST a return to the Channable returns webhook endpoint.
+   */
+  async postReturn(baseURL: string, returnData: any, storeId: number = 1): Promise<any> {
+    const token = process.env.CHANNABLE_TOKEN;
+    const url = `${baseURL}channable/returns/hook?store=${storeId}&code=${token}`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(returnData),
+    });
+
+    return response.json();
+  }
+
+  /**
+   * Build return data for the Channable returns webhook.
+   */
+  buildReturnData(overrides: {
+    channelId?: string;
+    channableId?: string;
+    productId?: number;
+    orderId?: string | null;
+    status?: string;
+    channelName?: string;
+  } = {}): any {
+    const random = String(Math.floor(Math.random() * 900000) + 100000);
+    const channableId = overrides.channableId || random;
+    const channelId = overrides.channelId || 'TEST-' + random;
+    const productId = overrides.productId || 1;
+
+    return {
+      status: overrides.status || 'new',
+      channel_name: overrides.channelName || 'Channable',
+      channel_id: channelId,
+      channable_id: channableId,
+      item: {
+        id: productId,
+        order_id: overrides.orderId ?? null,
+        gtin: 'E2E-SKU-' + random,
+        title: 'E2E Test Product',
+        quantity: 1,
+        reason: 'Test return',
+        comment: 'Do not process',
+      },
+      customer: {
+        gender: 'male',
+        first_name: 'Test',
+        last_name: 'Channable',
+        email: 'dontemail@me.net',
+      },
+      address: {
+        first_name: 'Test',
+        last_name: 'Channable',
+        email: 'dontemail@me.net',
+        street: 'Test street',
+        house_number: '1',
+        address1: 'Test street 1 bis',
+        address2: null,
+        city: 'Test',
+        country_code: 'NL',
+        zip_code: '1234 AB',
+      },
+      meta: {
+        channel_return_id: channelId + '-return',
+        channel_order_id: channelId + '-order',
+        channel_order_id_internal: channelId + '-internal',
+        platform_order_id: channelId + '-platform',
+      },
+    };
+  }
+
+  /**
    * Build order data by merging overrides into the base template.
    */
   buildOrderData(overrides: {

--- a/Test/End-2-end/tests/order/rest-api.spec.ts
+++ b/Test/End-2-end/tests/order/rest-api.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { test, expect } from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+
+const api = new ChannableApi();
+
+const PRODUCT_ID = parseInt(process.env.PRODUCT_ID || '1', 10);
+
+/**
+ * Helper: extract order increment ID from the Channable webhook response.
+ */
+function getOrderIncrementId(response: any): string {
+  if (response.order_id) {
+    return String(response.order_id);
+  }
+  throw new Error(`Order creation failed: ${JSON.stringify(response)}`);
+}
+
+test.describe('REST API — /V1/channable/orders', () => {
+  let channelId: string;
+  let incrementId: string;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Import an order via webhook so we have data to query
+    channelId = 'REST-API-E2E-' + Date.now();
+    const orderData = api.buildOrderData({
+      productId: PRODUCT_ID,
+      channelId,
+    });
+    const response = await api.postOrder(baseURL, orderData);
+    incrementId = getOrderIncrementId(response);
+    console.log(`Order imported for REST API test: ${incrementId} (channel_id: ${channelId})`);
+  });
+
+  test('returns orders filtered by channel_id', async ({ baseURL }) => {
+    const filter = encodeURIComponent(channelId);
+    const { status, body } = await api.restGet(
+      baseURL!,
+      `/channable/orders?searchCriteria[filterGroups][0][filters][0][field]=channel_id&searchCriteria[filterGroups][0][filters][0][value]=${filter}`
+    );
+
+    expect(status).toBe(200);
+    expect(body.items.length).toBeGreaterThanOrEqual(1);
+
+    const order = body.items.find((o: any) => o.channel_id === channelId);
+    expect(order).toBeDefined();
+    expect(order.magento_increment_id).toBe(incrementId);
+    expect(order.store_id).toBeTruthy();
+    expect(order.channable_id).toBeTruthy();
+    expect(order.created_at).toBeTruthy();
+  });
+
+  test('returns all orders without filter', async ({ baseURL }) => {
+    const { status, body } = await api.restGet(
+      baseURL!,
+      '/channable/orders?searchCriteria[pageSize]=5'
+    );
+
+    expect(status).toBe(200);
+    expect(body).toHaveProperty('items');
+    expect(body).toHaveProperty('total_count');
+    expect(body.items.length).toBeGreaterThanOrEqual(1);
+    expect(body.items.length).toBeLessThanOrEqual(5);
+
+    // Verify DTO shape — all expected fields present
+    const item = body.items[0];
+    expect(item).toHaveProperty('entity_id');
+    expect(item).toHaveProperty('channable_id');
+    expect(item).toHaveProperty('channel_id');
+    expect(item).toHaveProperty('store_id');
+    expect(item).toHaveProperty('status');
+    expect(item).toHaveProperty('created_at');
+  });
+
+  test('rejects unauthenticated requests', async ({ baseURL }) => {
+    const url = `${baseURL}rest/V1/channable/orders?searchCriteria[pageSize]=1`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+
+    expect(response.status).toBe(401);
+  });
+});
+
+test.describe('REST API — /V1/channable/returns', () => {
+  let channelId: string;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Enable returns
+    await api.setMagentoConfig(baseURL, {
+      'magmodules_channable_marketplace/returns/enable': '1',
+    });
+
+    // Import a return via webhook so we have data to query
+    channelId = 'REST-RETURN-E2E-' + Date.now();
+    const returnData = api.buildReturnData({
+      productId: PRODUCT_ID,
+      channelId,
+    });
+    const response = await api.postReturn(baseURL, returnData);
+    console.log(`Return imported for REST API test: channel_id=${channelId}`, response);
+  });
+
+  test('returns filtered by channel_id', async ({ baseURL }) => {
+    const filter = encodeURIComponent(channelId);
+    const { status, body } = await api.restGet(
+      baseURL!,
+      `/channable/returns?searchCriteria[filterGroups][0][filters][0][field]=channel_id&searchCriteria[filterGroups][0][filters][0][value]=${filter}`
+    );
+
+    expect(status).toBe(200);
+    expect(body.items.length).toBeGreaterThanOrEqual(1);
+
+    const ret = body.items.find((r: any) => r.channel_id === channelId);
+    expect(ret).toBeDefined();
+    expect(ret.channel_name).toBe('Channable');
+    expect(ret.status).toBeTruthy();
+    expect(ret.store_id).toBeTruthy();
+    expect(ret.created_at).toBeTruthy();
+  });
+
+  test('returns all without filter', async ({ baseURL }) => {
+    const { status, body } = await api.restGet(
+      baseURL!,
+      '/channable/returns?searchCriteria[pageSize]=5'
+    );
+
+    expect(status).toBe(200);
+    expect(body).toHaveProperty('items');
+    expect(body).toHaveProperty('total_count');
+    expect(body.items.length).toBeGreaterThanOrEqual(1);
+
+    // Verify DTO shape
+    const item = body.items[0];
+    expect(item).toHaveProperty('entity_id');
+    expect(item).toHaveProperty('channable_id');
+    expect(item).toHaveProperty('channel_id');
+    expect(item).toHaveProperty('channel_name');
+    expect(item).toHaveProperty('status');
+    expect(item).toHaveProperty('store_id');
+    expect(item).toHaveProperty('created_at');
+  });
+
+  test('rejects unauthenticated requests', async ({ baseURL }) => {
+    const url = `${baseURL}rest/V1/channable/returns?searchCriteria[pageSize]=1`;
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -172,6 +172,13 @@
     </type>
     <!-- Channable Returns Block End -->
 
+    <!-- Channable REST API Block Start -->
+    <preference for="Magmodules\Channable\Api\Order\SearchInterface"
+                type="Magmodules\Channable\Model\Api\OrderSearch"/>
+    <preference for="Magmodules\Channable\Api\Returns\SearchInterface"
+                type="Magmodules\Channable\Model\Api\ReturnsSearch"/>
+    <!-- Channable REST API Block End -->
+
     <!-- Channable Selftest Block Start -->
     <preference for="Magmodules\Channable\Api\Selftest\RepositoryInterface"
                 type="Magmodules\Channable\Model\Selftest\Repository"/>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -9,4 +9,6 @@
     <extension_attributes for="Magento\Quote\Api\Data\AddressInterface">
         <attribute code="channable_pickup_location" type="string"/>
     </extension_attributes>
+    <extension_attributes for="Magmodules\Channable\Api\Order\Data\DataInterface"/>
+    <extension_attributes for="Magmodules\Channable\Api\Returns\Data\DataInterface"/>
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
+<routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
+
+    <!-- Channable Orders API -->
+    <route url="/V1/channable/orders" method="GET">
+        <service class="Magmodules\Channable\Api\Order\SearchInterface" method="getList"/>
+        <resources>
+            <resource ref="Magmodules_Channable::order_view"/>
+        </resources>
+    </route>
+
+    <!-- Channable Returns API -->
+    <route url="/V1/channable/returns" method="GET">
+        <service class="Magmodules\Channable\Api\Returns\SearchInterface" method="getList"/>
+        <resources>
+            <resource ref="Magmodules_Channable::returns_view"/>
+        </resources>
+    </route>
+
+</routes>


### PR DESCRIPTION
## Summary
- Adds searchable REST API endpoints: `GET /V1/channable/orders` and `GET /V1/channable/returns` with `searchCriteria` support
- Includes E2E tests covering filtered queries, unfiltered listing, DTO shape validation, and auth rejection
