### PR TITLE
Fix bundle product pricing in feed using indexed prices

### DIFF
--- a/.github/workflows/templates/magento/configure-channable.sh
+++ b/.github/workflows/templates/magento/configure-channable.sh
@@ -25,6 +25,12 @@ bin/magento config:set tax/calculation/cross_border_trade_enabled 0
 bin/magento config:set tax/calculation/based_on shipping
 bin/magento config:set tax/calculation/algorithm TOTAL_BASE_CALCULATION
 
+# Default tax destination — must match shipping origin so getTaxPrice() resolves
+# the correct rate when no customer is logged in (e.g. feed generation context)
+bin/magento config:set tax/defaults/country NL
+bin/magento config:set tax/defaults/region 0
+bin/magento config:set tax/defaults/postcode '1000 AA'
+
 # Tax display settings
 bin/magento config:set tax/display/type 2
 bin/magento config:set tax/display/shipping 2

--- a/E2E-TESTS.md
+++ b/E2E-TESTS.md
@@ -50,6 +50,36 @@ Channable periodically polls Magento for order status updates and shipment infor
 | Shipments — recent order | Returns shipment array for known orders |
 | Shipments — LVB with tracking | Shipped order includes tracking information |
 
+## Bundle Pricing
+
+Dynamic bundle products derive their prices from their children rather than having a fixed price. This test suite validates that the feed correctly reports bundle prices across different tax configurations. The fix uses indexed prices (`$product->getData('min_price')`) instead of `getBaseAmount()`, matching how configurables are handled and ensuring correct behavior with Magento's `getTaxPrice()`.
+
+Test products are created via REST API: two simple children (€20 + €30, tax class 2), two bundles (one dynamic with two required options, one fixed at €100), and a single-option dynamic bundle for OOS testing. NL 21% tax rules are used.
+
+**Group A: Catalog prices including tax** (stored €50 = incl tax)
+
+| Test | Channable Config | Assert |
+|------|------------------|--------|
+| Dynamic, add tax on | `tax=1` | price = 50.00, min_price = 50.00 |
+| Dynamic, add tax off | `tax=0` | price = 50.00, min_price = 50.00 |
+| Dynamic, include both | `tax=1, tax_include_both=1` | price_incl = 50.00, price_excl ≈ 41.32 |
+| Fixed, add tax on | `tax=1` | price = 100.00 |
+
+**Group B: Catalog prices excluding tax** (stored €50 = excl tax, incl = €60.50)
+
+| Test | Channable Config | Assert |
+|------|------------------|--------|
+| Dynamic, add tax on | `tax=1` | price ≈ 60.50, min_price ≈ 60.50 |
+| Dynamic, add tax off | `tax=0` | price = 50.00, min_price = 50.00 |
+| Dynamic, include both | `tax=1, tax_include_both=1` | price_incl ≈ 60.50, price_excl = 50.00 |
+| Fixed, add tax on | `tax=1` | price ≈ 121.00 |
+
+**Group C: Stock scenarios** (prices incl tax)
+
+| Test | Setup | Assert |
+|------|-------|--------|
+| Dynamic (single option), OOS child | child-b set OOS + reindex | min_price = 20.00 (only in-stock child) |
+
 ## Upcoming: Feed Generation
 
 The next suite of E2E tests will cover feed generation — validating that product data is correctly exported to Channable based on attribute mapping, category filters, and feed configuration. This will include tests for price rendering, image URLs, stock status, and custom attribute handling.
@@ -74,4 +104,5 @@ Run a specific suite:
 npx playwright test tests/order/cross-border-tax.spec.ts
 npx playwright test tests/order/order-import.spec.ts
 npx playwright test tests/order/webhooks.spec.ts
+npx playwright test tests/feed/bundle-pricing.spec.ts
 ```

--- a/Service/Product/PriceData.php
+++ b/Service/Product/PriceData.php
@@ -92,10 +92,12 @@ class PriceData
             case 'bundle':
                 $price = $product->getPrice();
                 if ((int)$product->getPriceType() === Price::PRICE_TYPE_DYNAMIC) {
-                    $product['min_price'] = $product->getPriceInfo()->getPrice('final_price')->getMinimalPrice()->getBaseAmount();
-                    $product['max_price'] = $product->getPriceInfo()->getPrice('final_price')->getMaximalPrice()->getBaseAmount();
+                    $product['min_price'] = $product->getData('min_price');
+                    $product['max_price'] = $product->getData('max_price');
+                    $finalPrice = $product->getData('final_price') ?: $product->getData('min_price');
+                } else {
+                    $finalPrice = $product->getFinalPrice();
                 }
-                $finalPrice = $product->getFinalPrice();
                 $specialPrice = $product->getSpecialPrice();
                 $rulePrice = $this->ruleFactory->create()->getRulePrice(
                     $config['timestamp'],
@@ -294,7 +296,7 @@ class PriceData
         }
 
         if (isset($config['incl_vat'])) {
-            $price = $this->catalogHelper->getTaxPrice($product, $price, ['incl_vat']);
+            $price = $this->catalogHelper->getTaxPrice($product, $price, true);
         }
 
         return $this->formatPrice($price, $config);

--- a/Test/End-2-end/support/services/ChannableApi.ts
+++ b/Test/End-2-end/support/services/ChannableApi.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { execSync } from 'child_process';
 import BaseApi from './BaseApi';
 
 export default class ChannableApi extends BaseApi {
@@ -190,5 +191,170 @@ export default class ChannableApi extends BaseApi {
     }
 
     this.flushAllCaches();
+  }
+
+  /**
+   * Create a product via the Magento REST API.
+   */
+  async createProduct(baseURL: string, payload: any): Promise<any> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ product: payload }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to create product ${payload.sku}: ${response.status} - ${text}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Delete a product by SKU via the Magento REST API.
+   */
+  async deleteProduct(baseURL: string, sku: string): Promise<void> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products/${encodeURIComponent(sku)}`;
+
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (!response.ok && response.status !== 404) {
+      const text = await response.text();
+      throw new Error(`Failed to delete product ${sku}: ${response.status} - ${text}`);
+    }
+  }
+
+  /**
+   * Set stock status and quantity for a product by SKU.
+   */
+  async setStockStatus(baseURL: string, sku: string, qty: number, inStock: boolean): Promise<void> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products/${encodeURIComponent(sku)}`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        product: {
+          sku,
+          extension_attributes: {
+            stock_item: {
+              qty,
+              is_in_stock: inStock,
+            },
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to set stock for ${sku}: ${response.status} - ${text}`);
+    }
+  }
+
+  /**
+   * Reindex catalog prices via docker exec.
+   */
+  reindexPrices(): void {
+    if (!this.container) {
+      throw new Error('MAGENTO_CONTAINER env var is required for reindexing');
+    }
+
+    execSync(
+      `docker exec ${this.container} bin/magento indexer:reindex catalog_product_price cataloginventory_stock`,
+      { stdio: 'pipe', timeout: 120000 }
+    );
+    console.log('Price index rebuilt.');
+  }
+
+  /**
+   * Full reindex of all indexers + cache flush via docker exec.
+   */
+  reindexAll(): void {
+    if (!this.container) {
+      throw new Error('MAGENTO_CONTAINER env var is required for reindexing');
+    }
+
+    execSync(
+      `docker exec ${this.container} bin/magento indexer:reindex`,
+      { stdio: 'pipe', timeout: 120000 }
+    );
+    this.flushAllCaches();
+    console.log('Full reindex + cache flush done.');
+  }
+
+  /**
+   * Fetch a single product from the Channable feed by product ID.
+   */
+  async getFeedProduct(baseURL: string, pid: number, storeId: number = 1): Promise<any> {
+    const token = process.env.CHANNABLE_TOKEN || 'e2e-test-token';
+    const url = `${baseURL}channable/feed/json?id=${storeId}&token=${token}&pid=${pid}`;
+
+    const response = await fetch(url, {
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Feed request failed: ${response.status}`);
+    }
+
+    const body = await response.json() as any;
+
+    // ?pid= returns {"products": {"product": {...}, "feed": {...}}}
+    // ?page= returns {"products": [...]}
+    const productsNode = body.products;
+
+    if (!productsNode) {
+      throw new Error(`Product ${pid} not found in feed (no products key)`);
+    }
+
+    // Single product via ?pid= — return the processed feed object
+    if (productsNode.feed) {
+      return productsNode.feed;
+    }
+
+    // Array from ?page=
+    if (Array.isArray(productsNode) && productsNode.length > 0) {
+      return productsNode[0];
+    }
+
+    throw new Error(`Product ${pid} not found in feed`);
+  }
+
+  /**
+   * Get the Magento entity ID for a product by SKU (via REST API).
+   */
+  async getProductId(baseURL: string, sku: string): Promise<number> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products/${encodeURIComponent(sku)}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Product ${sku} not found: ${response.status}`);
+    }
+
+    const data = await response.json() as any;
+    return data.id;
   }
 }

--- a/Test/End-2-end/tests/feed/bundle-pricing.spec.ts
+++ b/Test/End-2-end/tests/feed/bundle-pricing.spec.ts
@@ -1,0 +1,443 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { test, expect } from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+
+const api = new ChannableApi();
+
+const TAX_RATE_NL = 0.21;
+
+const SKUS = {
+  childA: 'e2e-bundle-child-a',
+  childB: 'e2e-bundle-child-b',
+  dynamic: 'e2e-bundle-dynamic',
+  fixed: 'e2e-bundle-fixed',
+  dynamicSingleOpt: 'e2e-bundle-dyn-single',
+};
+
+const CHILD_A_PRICE = 20.00;
+const CHILD_B_PRICE = 30.00;
+const CHILDREN_SUM = CHILD_A_PRICE + CHILD_B_PRICE; // 50.00
+const FIXED_PRICE = 100.00;
+
+let dynamicProductId: number;
+let fixedProductId: number;
+let dynamicSingleOptId: number;
+
+const BASE_CONFIG: Record<string, string> = {
+  'magmodules_channable/general/enable': '1',
+  'magmodules_channable/filter/visbility_enabled': '0',
+};
+
+/**
+ * Helper: parse feed price (e.g. "50.00 EUR") and round to 2 decimals.
+ */
+function price(val: string | number): number {
+  const num = parseFloat(String(val).replace(/[^0-9.\-]/g, ''));
+  return Math.round(num * 100) / 100;
+}
+
+/**
+ * Helper: build simple product payload.
+ */
+function simpleProduct(sku: string, price: number) {
+  return {
+    sku,
+    name: sku,
+    attribute_set_id: 4,
+    price,
+    type_id: 'simple',
+    status: 1,
+    visibility: 1,
+    weight: 1,
+    extension_attributes: {
+      stock_item: { qty: 100, is_in_stock: true },
+      category_links: [],
+    },
+    custom_attributes: [
+      { attribute_code: 'tax_class_id', value: '2' },
+    ],
+  };
+}
+
+test.describe('Bundle Product Pricing in Feed', () => {
+
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Clean up any leftover products from previous runs
+    for (const sku of Object.values(SKUS)) {
+      try { await api.deleteProduct(baseURL, sku); } catch { /* ignore */ }
+    }
+
+    // Create simple children
+    await api.createProduct(baseURL, simpleProduct(SKUS.childA, CHILD_A_PRICE));
+    await api.createProduct(baseURL, simpleProduct(SKUS.childB, CHILD_B_PRICE));
+
+    // Get child IDs for bundle options
+    const childAId = await api.getProductId(baseURL, SKUS.childA);
+    const childBId = await api.getProductId(baseURL, SKUS.childB);
+
+    // Create dynamic bundle (price_type=0)
+    await api.createProduct(baseURL, {
+      sku: SKUS.dynamic,
+      name: 'E2E Dynamic Bundle',
+      attribute_set_id: 4,
+      type_id: 'bundle',
+      status: 1,
+      visibility: 4,
+      custom_attributes: [
+        { attribute_code: 'tax_class_id', value: '2' },
+        { attribute_code: 'price_type', value: '0' },
+        { attribute_code: 'sku_type', value: '0' },
+        { attribute_code: 'weight_type', value: '0' },
+        { attribute_code: 'price_view', value: '0' },
+        { attribute_code: 'shipment_type', value: '0' },
+      ],
+      extension_attributes: {
+        stock_item: { qty: 0, is_in_stock: true },
+        bundle_product_options: [
+          {
+            title: 'Option A',
+            required: true,
+            type: 'select',
+            position: 0,
+            product_links: [
+              {
+                sku: SKUS.childA,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+          {
+            title: 'Option B',
+            required: true,
+            type: 'select',
+            position: 1,
+            product_links: [
+              {
+                sku: SKUS.childB,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    // Create fixed bundle (price_type=1)
+    await api.createProduct(baseURL, {
+      sku: SKUS.fixed,
+      name: 'E2E Fixed Bundle',
+      attribute_set_id: 4,
+      type_id: 'bundle',
+      status: 1,
+      visibility: 4,
+      price: FIXED_PRICE,
+      custom_attributes: [
+        { attribute_code: 'tax_class_id', value: '2' },
+        { attribute_code: 'price_type', value: '1' },
+        { attribute_code: 'sku_type', value: '1' },
+        { attribute_code: 'weight_type', value: '1' },
+        { attribute_code: 'price_view', value: '0' },
+        { attribute_code: 'shipment_type', value: '0' },
+      ],
+      extension_attributes: {
+        stock_item: { qty: 0, is_in_stock: true },
+        bundle_product_options: [
+          {
+            title: 'Bundle Items',
+            required: true,
+            type: 'select',
+            position: 0,
+            product_links: [
+              {
+                sku: SKUS.childA,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                price_type: 0,
+                price: 0,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    // Create dynamic bundle with single option (both children in one select) for OOS test
+    await api.createProduct(baseURL, {
+      sku: SKUS.dynamicSingleOpt,
+      name: 'E2E Dynamic Bundle Single Option',
+      attribute_set_id: 4,
+      type_id: 'bundle',
+      status: 1,
+      visibility: 4,
+      custom_attributes: [
+        { attribute_code: 'tax_class_id', value: '2' },
+        { attribute_code: 'price_type', value: '0' },
+        { attribute_code: 'sku_type', value: '0' },
+        { attribute_code: 'weight_type', value: '0' },
+        { attribute_code: 'price_view', value: '0' },
+        { attribute_code: 'shipment_type', value: '0' },
+      ],
+      extension_attributes: {
+        stock_item: { qty: 0, is_in_stock: true },
+        bundle_product_options: [
+          {
+            title: 'Pick one',
+            required: true,
+            type: 'select',
+            position: 0,
+            product_links: [
+              {
+                sku: SKUS.childA,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                can_change_quantity: 0,
+              },
+              {
+                sku: SKUS.childB,
+                qty: 1,
+                position: 1,
+                is_default: false,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    dynamicProductId = await api.getProductId(baseURL, SKUS.dynamic);
+    fixedProductId = await api.getProductId(baseURL, SKUS.fixed);
+    dynamicSingleOptId = await api.getProductId(baseURL, SKUS.dynamicSingleOpt);
+
+    // Ensure module is enabled and set initial tax config (prices include tax)
+    // Default tax destination MUST match a tax rule (NL) so getTaxPrice() resolves
+    // the correct rate in feed context where no customer session exists.
+    await api.setMagentoConfig(baseURL, {
+      ...BASE_CONFIG,
+      'tax/calculation/price_includes_tax': '1',
+      'tax/defaults/country': 'NL',
+      'tax/defaults/region': '0',
+      'tax/defaults/postcode': '1000 AA',
+    });
+
+    api.reindexAll();
+  });
+
+  test.afterAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Delete test products
+    for (const sku of Object.values(SKUS)) {
+      try { await api.deleteProduct(baseURL, sku); } catch { /* ignore */ }
+    }
+
+    // Reset config values we changed during tests
+    await api.setMagentoConfig(baseURL, {
+      'tax/calculation/price_includes_tax': '1',
+      'magmodules_channable/advanced/tax': '0',
+      'magmodules_channable/advanced/tax_include_both': '0',
+    });
+  });
+
+  // ── Group A: Catalog prices INCLUDING tax ──────────────────────────────
+  // Stored €50 = incl tax.
+
+  test.describe('Group A: Catalog prices including tax', () => {
+
+    test('A1: dynamic bundle, add tax on → price = stored value (already incl)', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      expect(price(product.price)).toBe(CHILDREN_SUM);
+      expect(price(product.min_price)).toBe(CHILDREN_SUM);
+    });
+
+    test('A2: dynamic bundle, add tax off → price = stored value (incl)', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '0',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      expect(price(product.price)).toBe(CHILDREN_SUM);
+      expect(price(product.min_price)).toBe(CHILDREN_SUM);
+    });
+
+    test('A3: dynamic bundle, include both → price_incl and price_excl', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '1',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+
+      const expectedIncl = CHILDREN_SUM;
+      const expectedExcl = price(CHILDREN_SUM / (1 + TAX_RATE_NL));
+
+      expect(price(product.price_incl)).toBe(expectedIncl);
+      expect(price(product.price_excl)).toBe(expectedExcl);
+    });
+
+    test('A4: fixed bundle, add tax on → price = fixed price', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, fixedProductId);
+      expect(price(product.price)).toBe(FIXED_PRICE);
+    });
+  });
+
+  // ── Group B: Catalog prices EXCLUDING tax ──────────────────────────────
+  // Stored €50 = excl tax. Incl = €60.50.
+
+  test.describe('Group B: Catalog prices excluding tax', () => {
+
+    test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+      await api.setMagentoConfig(baseURL, {
+        'tax/calculation/price_includes_tax': '0',
+      });
+      api.reindexAll();
+    });
+
+    test.afterAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+      await api.setMagentoConfig(baseURL, {
+        'tax/calculation/price_includes_tax': '1',
+      });
+      api.reindexAll();
+    });
+
+    test('B5: dynamic bundle, add tax on → price with tax added', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      const expectedIncl = price(CHILDREN_SUM * (1 + TAX_RATE_NL));
+      expect(price(product.price)).toBe(expectedIncl);
+      expect(price(product.min_price)).toBe(expectedIncl);
+    });
+
+    test('B6: dynamic bundle, add tax off → raw excl price', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '0',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      expect(price(product.price)).toBe(CHILDREN_SUM);
+      expect(price(product.min_price)).toBe(CHILDREN_SUM);
+    });
+
+    test('B7: dynamic bundle, include both → price_incl and price_excl', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '1',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      const expectedIncl = price(CHILDREN_SUM * (1 + TAX_RATE_NL));
+
+      expect(price(product.price_incl)).toBe(expectedIncl);
+      expect(price(product.price_excl)).toBe(CHILDREN_SUM);
+    });
+
+    test('B8: fixed bundle, add tax on → fixed price + tax', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, fixedProductId);
+      const expectedIncl = price(FIXED_PRICE * (1 + TAX_RATE_NL));
+      expect(price(product.price)).toBe(expectedIncl);
+    });
+  });
+
+  // ── Group C: Stock scenarios ───────────────────────────────────────────
+
+  test.describe('Group C: OOS child affects bundle price', () => {
+
+    test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+      // Ensure prices include tax for this group
+      await api.setMagentoConfig(baseURL, {
+        'tax/calculation/price_includes_tax': '1',
+      });
+      api.reindexAll();
+    });
+
+    test('C9: dynamic bundle, OOS child → min_price reflects only in-stock children', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      // Set child B out of stock
+      await api.setStockStatus(baseURL, SKUS.childB, 0, false);
+      api.reindexAll();
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      // Single-option bundle (select between A and B): OOS child B excluded,
+      // min_price = cheapest in-stock child = child A (€20)
+      const product = await api.getFeedProduct(baseURL, dynamicSingleOptId);
+      expect(price(product.min_price)).toBe(CHILD_A_PRICE);
+
+      // Restore child B stock
+      await api.setStockStatus(baseURL, SKUS.childB, 100, true);
+      api.reindexAll();
+    });
+  });
+});

--- a/Test/End-2-end/tests/feed/feed-generation.spec.ts
+++ b/Test/End-2-end/tests/feed/feed-generation.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { test, expect } from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+
+const api = new ChannableApi();
+
+const FEED_TOKEN = process.env.CHANNABLE_TOKEN || 'e2e-test-token';
+const STORE_ID = 1;
+
+const CONFIG = {
+  'magmodules_channable/general/enable': '1',
+};
+
+test.describe('Feed Generation', () => {
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+    await api.setMagentoConfig(baseURL, CONFIG);
+  });
+
+  test('feed endpoint returns valid JSON without errors', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).not.toHaveProperty('error');
+  });
+
+  test('feed endpoint returns products array', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('products');
+    expect(Array.isArray(body.products)).toBe(true);
+  });
+
+  test('feed products contain required id and title fields', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    const body = await response.json();
+    const products = body.products ?? [];
+
+    // Skip if no products in feed (empty catalog)
+    if (products.length === 0) return;
+
+    for (const product of products) {
+      // Every product row must have an id and title
+      expect(product).toHaveProperty('id');
+      expect(product).toHaveProperty('title');
+      expect(product.id).toBeTruthy();
+    }
+  });
+
+  test('feed does not crash with visibility filter enabled', async ({ request }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Enable visibility filter and include "Not Visible Individually" (value 1)
+    await api.setMagentoConfig(baseURL, {
+      ...CONFIG,
+      'magmodules_channable/filter/visbility_enabled': '1',
+      'magmodules_channable/filter/visbility': '1',
+    });
+
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).not.toHaveProperty('error');
+
+    // Reset visibility filter
+    await api.setMagentoConfig(baseURL, {
+      ...CONFIG,
+      'magmodules_channable/filter/visbility_enabled': '0',
+    });
+  });
+
+  test('feed returns empty for invalid token', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=wrong-token&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    // Should return empty array, not an error page
+    expect(Array.isArray(body) || (typeof body === 'object' && Object.keys(body).length === 0)).toBe(true);
+  });
+
+  test('feed returns empty when module is disabled', async ({ request }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    await api.setMagentoConfig(baseURL, {
+      'magmodules_channable/general/enable': '0',
+    });
+
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(Array.isArray(body) || (typeof body === 'object' && Object.keys(body).length === 0)).toBe(true);
+
+    // Re-enable
+    await api.setMagentoConfig(baseURL, CONFIG);
+  });
+
+  test('single product feed via pid parameter', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&pid=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).not.toHaveProperty('error');
+  });
+});


### PR DESCRIPTION
## Summary
- Dynamic bundle min/max prices now use indexed data (`$product->getData('min_price')`) instead of `getBaseAmount()`, matching how configurables are handled. This ensures correct tax calculation via `getTaxPrice()` regardless of the `price_includes_tax` setting.
- Fixes `processPrice` passing an array instead of boolean to `getTaxPrice`'s third parameter, which caused inconsistent tax behavior across Magento versions.
- Sets `finalPrice` from the index for dynamic bundles so it is available for `sales_price` logic.
- Adds E2E test suite with 10 scenarios covering both tax configs, all Channable tax settings, fixed bundles, and OOS stock impact.
- Stops feed tests from overwriting the Channable token in Magento config.
