### PR TITLE
Release v1.24.2

### DIFF
--- a/.github/workflows/setup-upgrade.yml
+++ b/.github/workflows/setup-upgrade.yml
@@ -14,6 +14,8 @@ jobs:
             MAGENTO_VERSION: 2.4.7
           - PHP_VERSION: php84-fpm
             MAGENTO_VERSION: 2.4.8-p2
+          - PHP_VERSION: php85-fpm
+            MAGENTO_VERSION: 2.4.9
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/templates/magento/configure-channable.sh
+++ b/.github/workflows/templates/magento/configure-channable.sh
@@ -25,6 +25,12 @@ bin/magento config:set tax/calculation/cross_border_trade_enabled 0
 bin/magento config:set tax/calculation/based_on shipping
 bin/magento config:set tax/calculation/algorithm TOTAL_BASE_CALCULATION
 
+# Default tax destination — must match shipping origin so getTaxPrice() resolves
+# the correct rate when no customer is logged in (e.g. feed generation context)
+bin/magento config:set tax/defaults/country NL
+bin/magento config:set tax/defaults/region 0
+bin/magento config:set tax/defaults/postcode '1000 AA'
+
 # Tax display settings
 bin/magento config:set tax/display/type 2
 bin/magento config:set tax/display/shipping 2

--- a/E2E-TESTS.md
+++ b/E2E-TESTS.md
@@ -80,6 +80,17 @@ Test products are created via REST API: two simple children (€20 + €30, tax 
 |------|-------|--------|
 | Dynamic (single option), OOS child | child-b set OOS + reindex | min_price = 20.00 (only in-stock child) |
 
+## Credit Memo
+
+Validates that orders placed through the Channable payment method can be refunded — both via the Magento admin UI and the REST API.
+
+Both tests create an auto-invoiced order (`invoice_order: 1`), then attempt to create a credit memo.
+
+| Test | Expected |
+|------|----------|
+| Credit memo via admin UI | Credit memo created successfully through invoice → Credit Memo → Refund Offline flow |
+| Credit memo via REST API (`V1/invoice/:id/refund`) | API returns 200 with credit memo ID, credit memo record exists in DB |
+
 ## Upcoming: Feed Generation
 
 The next suite of E2E tests will cover feed generation — validating that product data is correctly exported to Channable based on attribute mapping, category filters, and feed configuration. This will include tests for price rendering, image URLs, stock status, and custom attribute handling.
@@ -105,4 +116,5 @@ npx playwright test tests/order/cross-border-tax.spec.ts
 npx playwright test tests/order/order-import.spec.ts
 npx playwright test tests/order/webhooks.spec.ts
 npx playwright test tests/feed/bundle-pricing.spec.ts
+npx playwright test tests/order/credit-memo.spec.ts
 ```

--- a/E2E-TESTS.md
+++ b/E2E-TESTS.md
@@ -50,6 +50,36 @@ Channable periodically polls Magento for order status updates and shipment infor
 | Shipments — recent order | Returns shipment array for known orders |
 | Shipments — LVB with tracking | Shipped order includes tracking information |
 
+## Bundle Pricing
+
+Dynamic bundle products derive their prices from their children rather than having a fixed price. This test suite validates that the feed correctly reports bundle prices across different tax configurations. The fix uses indexed prices (`$product->getData('min_price')`) instead of `getBaseAmount()`, matching how configurables are handled and ensuring correct behavior with Magento's `getTaxPrice()`.
+
+Test products are created via REST API: two simple children (€20 + €30, tax class 2), two bundles (one dynamic with two required options, one fixed at €100), and a single-option dynamic bundle for OOS testing. NL 21% tax rules are used.
+
+**Group A: Catalog prices including tax** (stored €50 = incl tax)
+
+| Test | Channable Config | Assert |
+|------|------------------|--------|
+| Dynamic, add tax on | `tax=1` | price = 50.00, min_price = 50.00 |
+| Dynamic, add tax off | `tax=0` | price = 50.00, min_price = 50.00 |
+| Dynamic, include both | `tax=1, tax_include_both=1` | price_incl = 50.00, price_excl ≈ 41.32 |
+| Fixed, add tax on | `tax=1` | price = 100.00 |
+
+**Group B: Catalog prices excluding tax** (stored €50 = excl tax, incl = €60.50)
+
+| Test | Channable Config | Assert |
+|------|------------------|--------|
+| Dynamic, add tax on | `tax=1` | price ≈ 60.50, min_price ≈ 60.50 |
+| Dynamic, add tax off | `tax=0` | price = 50.00, min_price = 50.00 |
+| Dynamic, include both | `tax=1, tax_include_both=1` | price_incl ≈ 60.50, price_excl = 50.00 |
+| Fixed, add tax on | `tax=1` | price ≈ 121.00 |
+
+**Group C: Stock scenarios** (prices incl tax)
+
+| Test | Setup | Assert |
+|------|-------|--------|
+| Dynamic (single option), OOS child | child-b set OOS + reindex | min_price = 20.00 (only in-stock child) |
+
 ## Upcoming: Feed Generation
 
 The next suite of E2E tests will cover feed generation — validating that product data is correctly exported to Channable based on attribute mapping, category filters, and feed configuration. This will include tests for price rendering, image URLs, stock status, and custom attribute handling.
@@ -74,4 +104,5 @@ Run a specific suite:
 npx playwright test tests/order/cross-border-tax.spec.ts
 npx playwright test tests/order/order-import.spec.ts
 npx playwright test tests/order/webhooks.spec.ts
+npx playwright test tests/feed/bundle-pricing.spec.ts
 ```

--- a/Model/Item.php
+++ b/Model/Item.php
@@ -513,6 +513,23 @@ class Item extends AbstractModel
     /**
      *
      */
+    /**
+     * Force getId() to return the actual primary key (item_id) instead of
+     * the `id` column, which holds the Magento product ID. Without this
+     * override, AbstractModel::getId() returns getData('id') which causes
+     * constraint violations on save because Magento uses getId() as the
+     * WHERE clause value for the item_id primary key column.
+     */
+    public function getId()
+    {
+        return $this->getData('item_id');
+    }
+
+    public function setId($value)
+    {
+        return $this->setData('item_id', $value);
+    }
+
     protected function _construct()
     {
         $this->_init('Magmodules\Channable\Model\ResourceModel\Item');

--- a/Model/Item.php
+++ b/Model/Item.php
@@ -131,6 +131,10 @@ class Item extends AbstractModel
      */
     public function add($row, $storeId)
     {
+        if (empty($row['id'])) {
+            return;
+        }
+
         $data = [];
         $data['item_id'] = $storeId . sprintf('%08d', $row['id']);
         $data['store_id'] = $storeId;

--- a/Model/Payment/Channable.php
+++ b/Model/Payment/Channable.php
@@ -13,6 +13,8 @@ class Channable extends AbstractMethod
     public const CODE = 'channable';
     protected $_code = self::CODE;
     protected $_isOffline = true;
+    protected $_canRefund = true;
+    protected $_canRefundInvoicePartial = true;
     protected $_canUseCheckout = false;
     protected $_canUseInternal = true;
     protected $_infoBlockType = 'Magmodules\Channable\Block\Info\Channable';

--- a/Service/Order/Quote/CustomerHandler.php
+++ b/Service/Order/Quote/CustomerHandler.php
@@ -92,6 +92,7 @@ class CustomerHandler
         } catch (NoSuchEntityException $exception) {
             $customer = $this->customerFactory->create();
             $customer->setWebsiteId($websiteId);
+            $customer->setStoreId((int)$storeId);
             $customer->setFirstname($this->validateName($orderData['customer']['first_name'], 'first_name'));
             $customer->setMiddlename($this->validateName($orderData['customer']['middle_name'], 'middle_name'));
             $customer->setLastname($this->validateName($orderData['customer']['last_name'], 'last_name'));

--- a/Service/Product/PriceData.php
+++ b/Service/Product/PriceData.php
@@ -92,10 +92,12 @@ class PriceData
             case 'bundle':
                 $price = $product->getPrice();
                 if ((int)$product->getPriceType() === Price::PRICE_TYPE_DYNAMIC) {
-                    $product['min_price'] = $product->getPriceInfo()->getPrice('final_price')->getMinimalPrice()->getBaseAmount();
-                    $product['max_price'] = $product->getPriceInfo()->getPrice('final_price')->getMaximalPrice()->getBaseAmount();
+                    $product['min_price'] = $product->getData('min_price');
+                    $product['max_price'] = $product->getData('max_price');
+                    $finalPrice = $product->getData('final_price') ?: $product->getData('min_price');
+                } else {
+                    $finalPrice = $product->getFinalPrice();
                 }
-                $finalPrice = $product->getFinalPrice();
                 $specialPrice = $product->getSpecialPrice();
                 $rulePrice = $this->ruleFactory->create()->getRulePrice(
                     $config['timestamp'],
@@ -294,7 +296,7 @@ class PriceData
         }
 
         if (isset($config['incl_vat'])) {
-            $price = $this->catalogHelper->getTaxPrice($product, $price, ['incl_vat']);
+            $price = $this->catalogHelper->getTaxPrice($product, $price, true);
         }
 
         return $this->formatPrice($price, $config);

--- a/Test/End-2-end/support/services/ChannableApi.ts
+++ b/Test/End-2-end/support/services/ChannableApi.ts
@@ -5,6 +5,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { execSync } from 'child_process';
 import BaseApi from './BaseApi';
 
 export default class ChannableApi extends BaseApi {
@@ -190,5 +191,170 @@ export default class ChannableApi extends BaseApi {
     }
 
     this.flushAllCaches();
+  }
+
+  /**
+   * Create a product via the Magento REST API.
+   */
+  async createProduct(baseURL: string, payload: any): Promise<any> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({ product: payload }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to create product ${payload.sku}: ${response.status} - ${text}`);
+    }
+
+    return response.json();
+  }
+
+  /**
+   * Delete a product by SKU via the Magento REST API.
+   */
+  async deleteProduct(baseURL: string, sku: string): Promise<void> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products/${encodeURIComponent(sku)}`;
+
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+
+    if (!response.ok && response.status !== 404) {
+      const text = await response.text();
+      throw new Error(`Failed to delete product ${sku}: ${response.status} - ${text}`);
+    }
+  }
+
+  /**
+   * Set stock status and quantity for a product by SKU.
+   */
+  async setStockStatus(baseURL: string, sku: string, qty: number, inStock: boolean): Promise<void> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products/${encodeURIComponent(sku)}`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        product: {
+          sku,
+          extension_attributes: {
+            stock_item: {
+              qty,
+              is_in_stock: inStock,
+            },
+          },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Failed to set stock for ${sku}: ${response.status} - ${text}`);
+    }
+  }
+
+  /**
+   * Reindex catalog prices via docker exec.
+   */
+  reindexPrices(): void {
+    if (!this.container) {
+      throw new Error('MAGENTO_CONTAINER env var is required for reindexing');
+    }
+
+    execSync(
+      `docker exec ${this.container} bin/magento indexer:reindex catalog_product_price cataloginventory_stock`,
+      { stdio: 'pipe', timeout: 120000 }
+    );
+    console.log('Price index rebuilt.');
+  }
+
+  /**
+   * Full reindex of all indexers + cache flush via docker exec.
+   */
+  reindexAll(): void {
+    if (!this.container) {
+      throw new Error('MAGENTO_CONTAINER env var is required for reindexing');
+    }
+
+    execSync(
+      `docker exec ${this.container} bin/magento indexer:reindex`,
+      { stdio: 'pipe', timeout: 120000 }
+    );
+    this.flushAllCaches();
+    console.log('Full reindex + cache flush done.');
+  }
+
+  /**
+   * Fetch a single product from the Channable feed by product ID.
+   */
+  async getFeedProduct(baseURL: string, pid: number, storeId: number = 1): Promise<any> {
+    const token = process.env.CHANNABLE_TOKEN || 'e2e-test-token';
+    const url = `${baseURL}channable/feed/json?id=${storeId}&token=${token}&pid=${pid}`;
+
+    const response = await fetch(url, {
+      headers: { 'Accept': 'application/json' },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Feed request failed: ${response.status}`);
+    }
+
+    const body = await response.json() as any;
+
+    // ?pid= returns {"products": {"product": {...}, "feed": {...}}}
+    // ?page= returns {"products": [...]}
+    const productsNode = body.products;
+
+    if (!productsNode) {
+      throw new Error(`Product ${pid} not found in feed (no products key)`);
+    }
+
+    // Single product via ?pid= — return the processed feed object
+    if (productsNode.feed) {
+      return productsNode.feed;
+    }
+
+    // Array from ?page=
+    if (Array.isArray(productsNode) && productsNode.length > 0) {
+      return productsNode[0];
+    }
+
+    throw new Error(`Product ${pid} not found in feed`);
+  }
+
+  /**
+   * Get the Magento entity ID for a product by SKU (via REST API).
+   */
+  async getProductId(baseURL: string, sku: string): Promise<number> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/products/${encodeURIComponent(sku)}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Product ${sku} not found: ${response.status}`);
+    }
+
+    const data = await response.json() as any;
+    return data.id;
   }
 }

--- a/Test/End-2-end/support/services/ChannableApi.ts
+++ b/Test/End-2-end/support/services/ChannableApi.ts
@@ -65,6 +65,31 @@ export default class ChannableApi extends BaseApi {
   }
 
   /**
+   * GET a customer by email via the Magento REST API.
+   */
+  async getCustomerByEmail(baseURL: string, email: string): Promise<any> {
+    const token = process.env.admin_token;
+    const searchUrl = `${baseURL}rest/V1/customers/search?` +
+      `searchCriteria[filterGroups][0][filters][0][field]=email&` +
+      `searchCriteria[filterGroups][0][filters][0][value]=${encodeURIComponent(email)}`;
+
+    const response = await fetch(searchUrl, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Accept': 'application/json',
+      },
+    });
+
+    const result = await response.json();
+    if (result.items && result.items.length > 0) {
+      return result.items[0];
+    }
+
+    throw new Error(`Customer not found for email: ${email}`);
+  }
+
+  /**
    * Build order data by merging overrides into the base template.
    */
   buildOrderData(overrides: {
@@ -85,6 +110,7 @@ export default class ChannableApi extends BaseApi {
     companyName?: string;
     channelName?: string;
     shipmentMethod?: string;
+    email?: string;
   } = {}): any {
     const channableId = overrides.channableId || String(Math.floor(Math.random() * 900000) + 100000);
     const country = overrides.country || 'NL';
@@ -149,6 +175,12 @@ export default class ChannableApi extends BaseApi {
       data.shipping.company = overrides.companyName;
     }
 
+    if (overrides.email) {
+      data.customer.email = overrides.email;
+      data.billing.email = overrides.email;
+      data.shipping.email = overrides.email;
+    }
+
     if (overrides.channelName) {
       data.channel_name = overrides.channelName;
     }
@@ -168,6 +200,58 @@ export default class ChannableApi extends BaseApi {
     data.products[0].commission = data.price.commission;
 
     return data;
+  }
+
+  /**
+   * Ensure a second store view exists for multi-store tests.
+   * Uses Magento bootstrap to create the store properly (triggers all observers/indexers).
+   * Returns the store ID, or null if no container is available.
+   */
+  ensureSecondStoreView(storeCode: string): number | null {
+    if (!this.container) return null;
+
+    const phpScript = [
+      '<?php',
+      'error_reporting(0);',
+      "require 'app/bootstrap.php';",
+      '$bootstrap = \\Magento\\Framework\\App\\Bootstrap::create(BP, $_SERVER);',
+      '$om = $bootstrap->getObjectManager();',
+      '$repo = $om->get(\\Magento\\Store\\Api\\StoreRepositoryInterface::class);',
+      'try {',
+      `    $store = $repo->get('${storeCode}');`,
+      '} catch (\\Magento\\Framework\\Exception\\NoSuchEntityException $e) {',
+      '    $store = $om->get(\\Magento\\Store\\Model\\StoreFactory::class)->create();',
+      `    $store->setCode('${storeCode}');`,
+      "    $store->setName('Second Store');",
+      '    $store->setWebsiteId(1);',
+      '    $store->setGroupId(1);',
+      '    $store->setIsActive(1);',
+      '    $store->setSortOrder(10);',
+      '    $store->save();',
+      '}',
+      'echo $store->getId();',
+    ].join('\n');
+
+    const tmpFile = '/tmp/e2e-create-store.php';
+    execSync(`docker exec -i ${this.container} tee ${tmpFile}`, {
+      input: phpScript,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const result = execSync(
+      `docker exec ${this.container} php ${tmpFile}`,
+      { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 120000 }
+    ).trim();
+
+    const storeId = parseInt(result, 10);
+
+    execSync(`docker exec ${this.container} bin/magento config:set --scope=stores --scope-code=${storeCode} magmodules_channable/general/enable 1`, { stdio: 'pipe' });
+    execSync(`docker exec ${this.container} bin/magento config:set --scope=stores --scope-code=${storeCode} magmodules_channable_marketplace/general/enable 1`, { stdio: 'pipe' });
+    execSync(`docker exec ${this.container} bin/magento indexer:reindex`, { stdio: 'pipe', timeout: 120000 });
+    this.flushAllCaches();
+    console.log(`Second store view '${storeCode}' ensured (ID: ${storeId}).`);
+
+    return storeId;
   }
 
   /**

--- a/Test/End-2-end/support/services/ChannableApi.ts
+++ b/Test/End-2-end/support/services/ChannableApi.ts
@@ -255,6 +255,102 @@ export default class ChannableApi extends BaseApi {
   }
 
   /**
+   * Get the invoice entity ID for an order by its increment ID (via REST API).
+   */
+  async getInvoiceId(baseURL: string, orderIncrementId: string): Promise<string> {
+    const token = process.env.admin_token;
+    const filter = encodeURIComponent(`searchCriteria[filterGroups][0][filters][0][field]=order_id&searchCriteria[filterGroups][0][filters][0][value]=${orderIncrementId}&searchCriteria[filterGroups][0][filters][0][conditionType]=eq&searchCriteria[pageSize]=1`);
+
+    // First get order entity ID
+    const orderUrl = `${baseURL}rest/all/V1/orders?searchCriteria[filterGroups][0][filters][0][field]=increment_id&searchCriteria[filterGroups][0][filters][0][value]=${orderIncrementId}&searchCriteria[pageSize]=1`;
+    const orderRes = await fetch(orderUrl, {
+      headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' },
+    });
+    const orderData = await orderRes.json() as any;
+    const orderId = orderData.items?.[0]?.entity_id;
+    if (!orderId) throw new Error(`Order not found: ${orderIncrementId}`);
+
+    // Then get invoice for that order
+    const invoiceUrl = `${baseURL}rest/all/V1/invoices?searchCriteria[filterGroups][0][filters][0][field]=order_id&searchCriteria[filterGroups][0][filters][0][value]=${orderId}&searchCriteria[pageSize]=1`;
+    const invoiceRes = await fetch(invoiceUrl, {
+      headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' },
+    });
+    const invoiceData = await invoiceRes.json() as any;
+    return String(invoiceData.items?.[0]?.entity_id || '');
+  }
+
+  /**
+   * Get order item info for an order by its increment ID (via REST API).
+   */
+  async getOrderItemInfo(baseURL: string, orderIncrementId: string): Promise<{ orderId: string; orderItemId: string; qty: number }> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/orders?searchCriteria[filterGroups][0][filters][0][field]=increment_id&searchCriteria[filterGroups][0][filters][0][value]=${orderIncrementId}&searchCriteria[pageSize]=1`;
+
+    const res = await fetch(url, {
+      headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' },
+    });
+    const data = await res.json() as any;
+    const order = data.items?.[0];
+    if (!order) throw new Error(`Order not found: ${orderIncrementId}`);
+
+    const item = order.items?.find((i: any) => i.product_type === 'simple') || order.items?.[0];
+    return {
+      orderId: String(order.entity_id),
+      orderItemId: String(item.item_id),
+      qty: item.qty_invoiced || item.qty_ordered,
+    };
+  }
+
+  /**
+   * Refund an invoice via the Magento REST API.
+   */
+  async refundInvoiceViaApi(baseURL: string, invoiceId: string, orderItemId: string, qty: number): Promise<{ status: number; body: any }> {
+    const token = process.env.admin_token;
+    const url = `${baseURL}rest/all/V1/invoice/${invoiceId}/refund`;
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        items: [{ order_item_id: parseInt(orderItemId, 10), qty }],
+        notify: false,
+        isOnline: false,
+        arguments: { adjustment_positive: 0, adjustment_negative: 0, shipping_amount: 0 },
+      }),
+    });
+
+    const body = await response.json();
+    return { status: response.status, body };
+  }
+
+  /**
+   * Check if a credit memo exists for an order by increment ID (via REST API).
+   */
+  async hasCreditMemo(baseURL: string, orderIncrementId: string): Promise<boolean> {
+    const token = process.env.admin_token;
+
+    // Get order entity ID first
+    const orderUrl = `${baseURL}rest/all/V1/orders?searchCriteria[filterGroups][0][filters][0][field]=increment_id&searchCriteria[filterGroups][0][filters][0][value]=${orderIncrementId}&searchCriteria[pageSize]=1`;
+    const orderRes = await fetch(orderUrl, {
+      headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' },
+    });
+    const orderData = await orderRes.json() as any;
+    const orderId = orderData.items?.[0]?.entity_id;
+    if (!orderId) return false;
+
+    // Search for credit memos on that order
+    const cmUrl = `${baseURL}rest/all/V1/creditmemos?searchCriteria[filterGroups][0][filters][0][field]=order_id&searchCriteria[filterGroups][0][filters][0][value]=${orderId}&searchCriteria[pageSize]=1`;
+    const cmRes = await fetch(cmUrl, {
+      headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/json' },
+    });
+    const cmData = await cmRes.json() as any;
+    return (cmData.total_count || 0) > 0;
+  }
+
+  /**
    * Ensure a currency rate exists in Magento (needed for multi-currency orders).
    */
   async setupCurrencyRate(from: string, to: string, rate: number): Promise<void> {

--- a/Test/End-2-end/tests/feed/bundle-pricing.spec.ts
+++ b/Test/End-2-end/tests/feed/bundle-pricing.spec.ts
@@ -1,0 +1,443 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { test, expect } from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+
+const api = new ChannableApi();
+
+const TAX_RATE_NL = 0.21;
+
+const SKUS = {
+  childA: 'e2e-bundle-child-a',
+  childB: 'e2e-bundle-child-b',
+  dynamic: 'e2e-bundle-dynamic',
+  fixed: 'e2e-bundle-fixed',
+  dynamicSingleOpt: 'e2e-bundle-dyn-single',
+};
+
+const CHILD_A_PRICE = 20.00;
+const CHILD_B_PRICE = 30.00;
+const CHILDREN_SUM = CHILD_A_PRICE + CHILD_B_PRICE; // 50.00
+const FIXED_PRICE = 100.00;
+
+let dynamicProductId: number;
+let fixedProductId: number;
+let dynamicSingleOptId: number;
+
+const BASE_CONFIG: Record<string, string> = {
+  'magmodules_channable/general/enable': '1',
+  'magmodules_channable/filter/visbility_enabled': '0',
+};
+
+/**
+ * Helper: parse feed price (e.g. "50.00 EUR") and round to 2 decimals.
+ */
+function price(val: string | number): number {
+  const num = parseFloat(String(val).replace(/[^0-9.\-]/g, ''));
+  return Math.round(num * 100) / 100;
+}
+
+/**
+ * Helper: build simple product payload.
+ */
+function simpleProduct(sku: string, price: number) {
+  return {
+    sku,
+    name: sku,
+    attribute_set_id: 4,
+    price,
+    type_id: 'simple',
+    status: 1,
+    visibility: 1,
+    weight: 1,
+    extension_attributes: {
+      stock_item: { qty: 100, is_in_stock: true },
+      category_links: [],
+    },
+    custom_attributes: [
+      { attribute_code: 'tax_class_id', value: '2' },
+    ],
+  };
+}
+
+test.describe('Bundle Product Pricing in Feed', () => {
+
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Clean up any leftover products from previous runs
+    for (const sku of Object.values(SKUS)) {
+      try { await api.deleteProduct(baseURL, sku); } catch { /* ignore */ }
+    }
+
+    // Create simple children
+    await api.createProduct(baseURL, simpleProduct(SKUS.childA, CHILD_A_PRICE));
+    await api.createProduct(baseURL, simpleProduct(SKUS.childB, CHILD_B_PRICE));
+
+    // Get child IDs for bundle options
+    const childAId = await api.getProductId(baseURL, SKUS.childA);
+    const childBId = await api.getProductId(baseURL, SKUS.childB);
+
+    // Create dynamic bundle (price_type=0)
+    await api.createProduct(baseURL, {
+      sku: SKUS.dynamic,
+      name: 'E2E Dynamic Bundle',
+      attribute_set_id: 4,
+      type_id: 'bundle',
+      status: 1,
+      visibility: 4,
+      custom_attributes: [
+        { attribute_code: 'tax_class_id', value: '2' },
+        { attribute_code: 'price_type', value: '0' },
+        { attribute_code: 'sku_type', value: '0' },
+        { attribute_code: 'weight_type', value: '0' },
+        { attribute_code: 'price_view', value: '0' },
+        { attribute_code: 'shipment_type', value: '0' },
+      ],
+      extension_attributes: {
+        stock_item: { qty: 0, is_in_stock: true },
+        bundle_product_options: [
+          {
+            title: 'Option A',
+            required: true,
+            type: 'select',
+            position: 0,
+            product_links: [
+              {
+                sku: SKUS.childA,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+          {
+            title: 'Option B',
+            required: true,
+            type: 'select',
+            position: 1,
+            product_links: [
+              {
+                sku: SKUS.childB,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    // Create fixed bundle (price_type=1)
+    await api.createProduct(baseURL, {
+      sku: SKUS.fixed,
+      name: 'E2E Fixed Bundle',
+      attribute_set_id: 4,
+      type_id: 'bundle',
+      status: 1,
+      visibility: 4,
+      price: FIXED_PRICE,
+      custom_attributes: [
+        { attribute_code: 'tax_class_id', value: '2' },
+        { attribute_code: 'price_type', value: '1' },
+        { attribute_code: 'sku_type', value: '1' },
+        { attribute_code: 'weight_type', value: '1' },
+        { attribute_code: 'price_view', value: '0' },
+        { attribute_code: 'shipment_type', value: '0' },
+      ],
+      extension_attributes: {
+        stock_item: { qty: 0, is_in_stock: true },
+        bundle_product_options: [
+          {
+            title: 'Bundle Items',
+            required: true,
+            type: 'select',
+            position: 0,
+            product_links: [
+              {
+                sku: SKUS.childA,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                price_type: 0,
+                price: 0,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    // Create dynamic bundle with single option (both children in one select) for OOS test
+    await api.createProduct(baseURL, {
+      sku: SKUS.dynamicSingleOpt,
+      name: 'E2E Dynamic Bundle Single Option',
+      attribute_set_id: 4,
+      type_id: 'bundle',
+      status: 1,
+      visibility: 4,
+      custom_attributes: [
+        { attribute_code: 'tax_class_id', value: '2' },
+        { attribute_code: 'price_type', value: '0' },
+        { attribute_code: 'sku_type', value: '0' },
+        { attribute_code: 'weight_type', value: '0' },
+        { attribute_code: 'price_view', value: '0' },
+        { attribute_code: 'shipment_type', value: '0' },
+      ],
+      extension_attributes: {
+        stock_item: { qty: 0, is_in_stock: true },
+        bundle_product_options: [
+          {
+            title: 'Pick one',
+            required: true,
+            type: 'select',
+            position: 0,
+            product_links: [
+              {
+                sku: SKUS.childA,
+                qty: 1,
+                position: 0,
+                is_default: true,
+                can_change_quantity: 0,
+              },
+              {
+                sku: SKUS.childB,
+                qty: 1,
+                position: 1,
+                is_default: false,
+                can_change_quantity: 0,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    dynamicProductId = await api.getProductId(baseURL, SKUS.dynamic);
+    fixedProductId = await api.getProductId(baseURL, SKUS.fixed);
+    dynamicSingleOptId = await api.getProductId(baseURL, SKUS.dynamicSingleOpt);
+
+    // Ensure module is enabled and set initial tax config (prices include tax)
+    // Default tax destination MUST match a tax rule (NL) so getTaxPrice() resolves
+    // the correct rate in feed context where no customer session exists.
+    await api.setMagentoConfig(baseURL, {
+      ...BASE_CONFIG,
+      'tax/calculation/price_includes_tax': '1',
+      'tax/defaults/country': 'NL',
+      'tax/defaults/region': '0',
+      'tax/defaults/postcode': '1000 AA',
+    });
+
+    api.reindexAll();
+  });
+
+  test.afterAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Delete test products
+    for (const sku of Object.values(SKUS)) {
+      try { await api.deleteProduct(baseURL, sku); } catch { /* ignore */ }
+    }
+
+    // Reset config values we changed during tests
+    await api.setMagentoConfig(baseURL, {
+      'tax/calculation/price_includes_tax': '1',
+      'magmodules_channable/advanced/tax': '0',
+      'magmodules_channable/advanced/tax_include_both': '0',
+    });
+  });
+
+  // ── Group A: Catalog prices INCLUDING tax ──────────────────────────────
+  // Stored €50 = incl tax.
+
+  test.describe('Group A: Catalog prices including tax', () => {
+
+    test('A1: dynamic bundle, add tax on → price = stored value (already incl)', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      expect(price(product.price)).toBe(CHILDREN_SUM);
+      expect(price(product.min_price)).toBe(CHILDREN_SUM);
+    });
+
+    test('A2: dynamic bundle, add tax off → price = stored value (incl)', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '0',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      expect(price(product.price)).toBe(CHILDREN_SUM);
+      expect(price(product.min_price)).toBe(CHILDREN_SUM);
+    });
+
+    test('A3: dynamic bundle, include both → price_incl and price_excl', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '1',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+
+      const expectedIncl = CHILDREN_SUM;
+      const expectedExcl = price(CHILDREN_SUM / (1 + TAX_RATE_NL));
+
+      expect(price(product.price_incl)).toBe(expectedIncl);
+      expect(price(product.price_excl)).toBe(expectedExcl);
+    });
+
+    test('A4: fixed bundle, add tax on → price = fixed price', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'tax/calculation/price_includes_tax': '1',
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, fixedProductId);
+      expect(price(product.price)).toBe(FIXED_PRICE);
+    });
+  });
+
+  // ── Group B: Catalog prices EXCLUDING tax ──────────────────────────────
+  // Stored €50 = excl tax. Incl = €60.50.
+
+  test.describe('Group B: Catalog prices excluding tax', () => {
+
+    test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+      await api.setMagentoConfig(baseURL, {
+        'tax/calculation/price_includes_tax': '0',
+      });
+      api.reindexAll();
+    });
+
+    test.afterAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+      await api.setMagentoConfig(baseURL, {
+        'tax/calculation/price_includes_tax': '1',
+      });
+      api.reindexAll();
+    });
+
+    test('B5: dynamic bundle, add tax on → price with tax added', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      const expectedIncl = price(CHILDREN_SUM * (1 + TAX_RATE_NL));
+      expect(price(product.price)).toBe(expectedIncl);
+      expect(price(product.min_price)).toBe(expectedIncl);
+    });
+
+    test('B6: dynamic bundle, add tax off → raw excl price', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '0',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      expect(price(product.price)).toBe(CHILDREN_SUM);
+      expect(price(product.min_price)).toBe(CHILDREN_SUM);
+    });
+
+    test('B7: dynamic bundle, include both → price_incl and price_excl', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '1',
+      });
+
+      const product = await api.getFeedProduct(baseURL, dynamicProductId);
+      const expectedIncl = price(CHILDREN_SUM * (1 + TAX_RATE_NL));
+
+      expect(price(product.price_incl)).toBe(expectedIncl);
+      expect(price(product.price_excl)).toBe(CHILDREN_SUM);
+    });
+
+    test('B8: fixed bundle, add tax on → fixed price + tax', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      const product = await api.getFeedProduct(baseURL, fixedProductId);
+      const expectedIncl = price(FIXED_PRICE * (1 + TAX_RATE_NL));
+      expect(price(product.price)).toBe(expectedIncl);
+    });
+  });
+
+  // ── Group C: Stock scenarios ───────────────────────────────────────────
+
+  test.describe('Group C: OOS child affects bundle price', () => {
+
+    test.beforeAll(async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+      // Ensure prices include tax for this group
+      await api.setMagentoConfig(baseURL, {
+        'tax/calculation/price_includes_tax': '1',
+      });
+      api.reindexAll();
+    });
+
+    test('C9: dynamic bundle, OOS child → min_price reflects only in-stock children', async ({}, testInfo) => {
+      const baseURL = testInfo.project.use.baseURL!;
+
+      // Set child B out of stock
+      await api.setStockStatus(baseURL, SKUS.childB, 0, false);
+      api.reindexAll();
+
+      await api.setMagentoConfig(baseURL, {
+        ...BASE_CONFIG,
+        'magmodules_channable/advanced/tax': '1',
+        'magmodules_channable/advanced/tax_include_both': '0',
+      });
+
+      // Single-option bundle (select between A and B): OOS child B excluded,
+      // min_price = cheapest in-stock child = child A (€20)
+      const product = await api.getFeedProduct(baseURL, dynamicSingleOptId);
+      expect(price(product.min_price)).toBe(CHILD_A_PRICE);
+
+      // Restore child B stock
+      await api.setStockStatus(baseURL, SKUS.childB, 100, true);
+      api.reindexAll();
+    });
+  });
+});

--- a/Test/End-2-end/tests/feed/feed-generation.spec.ts
+++ b/Test/End-2-end/tests/feed/feed-generation.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { test, expect } from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+
+const api = new ChannableApi();
+
+const FEED_TOKEN = process.env.CHANNABLE_TOKEN || 'e2e-test-token';
+const STORE_ID = 1;
+
+const CONFIG = {
+  'magmodules_channable/general/enable': '1',
+};
+
+test.describe('Feed Generation', () => {
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+    await api.setMagentoConfig(baseURL, CONFIG);
+  });
+
+  test('feed endpoint returns valid JSON without errors', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).not.toHaveProperty('error');
+  });
+
+  test('feed endpoint returns products array', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    const body = await response.json();
+    expect(body).toHaveProperty('products');
+    expect(Array.isArray(body.products)).toBe(true);
+  });
+
+  test('feed products contain required id and title fields', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    const body = await response.json();
+    const products = body.products ?? [];
+
+    // Skip if no products in feed (empty catalog)
+    if (products.length === 0) return;
+
+    for (const product of products) {
+      // Every product row must have an id and title
+      expect(product).toHaveProperty('id');
+      expect(product).toHaveProperty('title');
+      expect(product.id).toBeTruthy();
+    }
+  });
+
+  test('feed does not crash with visibility filter enabled', async ({ request }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Enable visibility filter and include "Not Visible Individually" (value 1)
+    await api.setMagentoConfig(baseURL, {
+      ...CONFIG,
+      'magmodules_channable/filter/visbility_enabled': '1',
+      'magmodules_channable/filter/visbility': '1',
+    });
+
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).not.toHaveProperty('error');
+
+    // Reset visibility filter
+    await api.setMagentoConfig(baseURL, {
+      ...CONFIG,
+      'magmodules_channable/filter/visbility_enabled': '0',
+    });
+  });
+
+  test('feed returns empty for invalid token', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=wrong-token&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    // Should return empty array, not an error page
+    expect(Array.isArray(body) || (typeof body === 'object' && Object.keys(body).length === 0)).toBe(true);
+  });
+
+  test('feed returns empty when module is disabled', async ({ request }, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    await api.setMagentoConfig(baseURL, {
+      'magmodules_channable/general/enable': '0',
+    });
+
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&page=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(Array.isArray(body) || (typeof body === 'object' && Object.keys(body).length === 0)).toBe(true);
+
+    // Re-enable
+    await api.setMagentoConfig(baseURL, CONFIG);
+  });
+
+  test('single product feed via pid parameter', async ({ request }) => {
+    const response = await request.get(`/channable/feed/json?id=${STORE_ID}&token=${FEED_TOKEN}&pid=1`);
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+    expect(body).not.toHaveProperty('error');
+  });
+});

--- a/Test/End-2-end/tests/order/credit-memo.spec.ts
+++ b/Test/End-2-end/tests/order/credit-memo.spec.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import {expect, test} from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+import OrderViewPage from 'Pages/backend/OrderViewPage';
+
+const channableApi = new ChannableApi();
+const orderViewPage = new OrderViewPage();
+
+const PRODUCT_ID = parseInt(process.env.PRODUCT_ID || '1', 10);
+const CONFIG_BASE = 'magmodules_channable_marketplace/order';
+
+function getOrderIncrementId(response: any): string {
+  if (response.order_id) {
+    return String(response.order_id);
+  }
+  throw new Error(`Order creation failed: ${JSON.stringify(response)}`);
+}
+
+/**
+ * Create an auto-invoiced order and return the increment ID.
+ */
+async function createInvoicedOrder(baseURL: string): Promise<string> {
+  await channableApi.setMagentoConfig(baseURL, {
+    [`${CONFIG_BASE}/invoice_order`]: '1',
+  });
+
+  const orderData = channableApi.buildOrderData({ productId: PRODUCT_ID });
+  const response = await channableApi.postOrder(baseURL, orderData);
+  return getOrderIncrementId(response);
+}
+
+test.describe('Credit Memo', () => {
+  test.beforeEach(async ({ baseURL }) => {
+    await channableApi.setMagentoConfig(baseURL, {
+      [`${CONFIG_BASE}/import_customer`]: '0',
+      [`${CONFIG_BASE}/invoice_order`]: '0',
+      [`${CONFIG_BASE}/lvb`]: '0',
+      [`${CONFIG_BASE}/lvb_ship`]: '0',
+      [`${CONFIG_BASE}/business_order`]: '0',
+    });
+  });
+
+  test('Credit memo via admin UI', async ({ page, baseURL }) => {
+    const incrementId = await createInvoicedOrder(baseURL);
+    console.log(`Order created: ${incrementId}`);
+
+    // Open order in admin and verify invoice exists
+    await orderViewPage.openByIncrementId(page, incrementId);
+    const hasInvoice = await orderViewPage.hasInvoice(page);
+    expect(hasInvoice).toBe(true);
+
+    // Navigate to Invoices tab in the order view sidebar
+    await page.getByRole('tab', { name: 'Invoices' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Click "View" on the first invoice row
+    const invoiceRow = page.locator('.data-row').first();
+    await invoiceRow.locator('a', { hasText: 'View' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Click "Credit Memo" button in the top button bar
+    await page.locator('button', { hasText: 'Credit Memo' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Submit the credit memo (click "Refund Offline" button)
+    await page.locator('button', { hasText: 'Refund Offline' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // Verify credit memo was created — check success message
+    const successMessage = page.locator('.message-success');
+    await expect(successMessage).toBeVisible({ timeout: 15000 });
+
+    const hasCreditMemo = await channableApi.hasCreditMemo(baseURL, incrementId);
+    expect(hasCreditMemo).toBe(true);
+  });
+
+  test('Credit memo via REST API (V1/invoice/:id/refund)', async ({ page, baseURL }) => {
+    const incrementId = await createInvoicedOrder(baseURL);
+    console.log(`Order created: ${incrementId}`);
+
+    // Get invoice and order item IDs via REST API
+    const invoiceId = await channableApi.getInvoiceId(baseURL, incrementId);
+    expect(invoiceId).toBeTruthy();
+
+    const itemInfo = await channableApi.getOrderItemInfo(baseURL, incrementId);
+    expect(itemInfo.orderItemId).toBeTruthy();
+
+    // Refund the invoice via REST API
+    const result = await channableApi.refundInvoiceViaApi(
+      baseURL,
+      invoiceId,
+      itemInfo.orderItemId,
+      itemInfo.qty,
+    );
+
+    console.log(`API refund response: ${result.status}`, result.body);
+
+    // Expect 200 OK — the response body is the credit memo ID (returned as string)
+    expect(result.status).toBe(200);
+    const creditMemoId = parseInt(String(result.body), 10);
+    expect(creditMemoId).toBeGreaterThan(0);
+
+    // Verify credit memo is visible in admin order view
+    await orderViewPage.openByIncrementId(page, incrementId);
+
+    // Check order status changed to "Closed" (fully refunded)
+    const status = await orderViewPage.getOrderStatus(page);
+    expect(status.toLowerCase()).toContain('closed');
+
+    // Navigate to Credit Memos tab and verify a credit memo row exists
+    await page.getByRole('tab', { name: 'Credit Memos' }).click();
+    await page.waitForLoadState('networkidle');
+
+    // The tab content panel is AJAX-loaded; force-open it via DOM
+    await page.evaluate(() => {
+      const panel = document.querySelector('#sales_order_view_tabs_order_creditmemos_content');
+      if (panel) {
+        (panel as HTMLElement).style.display = 'block';
+      }
+    });
+
+    const creditMemoRow = page.locator('#sales_order_view_tabs_order_creditmemos_content .data-row').first();
+    await expect(creditMemoRow).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/Test/End-2-end/tests/order/item-save.spec.ts
+++ b/Test/End-2-end/tests/order/item-save.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright Magmodules.eu. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+import { test, expect } from '@playwright/test';
+import ChannableApi from 'Services/ChannableApi';
+
+const api = new ChannableApi();
+
+const PRODUCT_ID = parseInt(process.env.PRODUCT_ID || '1', 10);
+const CONFIG_BASE = 'magmodules_channable_marketplace/item';
+
+/**
+ * Regression test for item_id / id field mismatch in channable_items.
+ *
+ * When "Product Updates" modus is set to Observer, saving MSI stock in admin
+ * triggers an item save on channable_items. The table has both `item_id` (PK)
+ * and `id` (Magento product ID) columns. Without the getId() override, Magento
+ * uses the wrong column value in the WHERE clause, causing constraint violations.
+ */
+test.describe('Item Updates — save regression', () => {
+  const STORE_ID = 1;
+  const ITEM_ID = `${STORE_ID}${String(PRODUCT_ID).padStart(8, '0')}`;
+
+  test.beforeAll(async ({}, testInfo) => {
+    const baseURL = testInfo.project.use.baseURL!;
+
+    // Enable item updates with observer modus
+    await api.setMagentoConfig(baseURL, {
+      [`${CONFIG_BASE}/enable`]: '1',
+      [`${CONFIG_BASE}/invalidation_modus`]: 'observer',
+    });
+
+    // Seed a channable_items row for our product (simulates initial feed sync)
+    api['db']!.query(`
+      $pdo->prepare("DELETE FROM channable_items WHERE item_id = ?")->execute(['${ITEM_ID}']);
+      $pdo->prepare("INSERT INTO channable_items (item_id, store_id, id, title, price, qty, is_in_stock, needs_update, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
+        ->execute(['${ITEM_ID}', ${STORE_ID}, ${PRODUCT_ID}, 'E2E Test Product', 19.99, 10, 1, 0, 'Success']);
+      echo 'seeded';
+    `);
+  });
+
+  test.afterAll(() => {
+    try {
+      api['db']!.query(`
+        $pdo->prepare("DELETE FROM channable_items WHERE item_id = ?")->execute(['${ITEM_ID}']);
+        echo 'cleaned';
+      `);
+    } catch {
+      // ignore
+    }
+  });
+
+  test('saving a product in admin should not cause constraint violation on channable_items', async ({ page }) => {
+    // 1. Verify item exists before we start
+    const before = api['db']!.query(`
+      $stmt = $pdo->prepare("SELECT needs_update, qty FROM channable_items WHERE item_id = ?");
+      $stmt->execute(['${ITEM_ID}']);
+      $row = $stmt->fetch(PDO::FETCH_ASSOC);
+      echo json_encode($row ?: 'not_found');
+    `);
+    const beforeData = JSON.parse(before.trim());
+    expect(beforeData).not.toBe('not_found');
+    expect(String(beforeData.needs_update)).toBe('0');
+
+    // 2. Open the product edit page in admin
+    await page.goto(`/admin/catalog/product/edit/id/${PRODUCT_ID}`);
+    await page.waitForLoadState('networkidle');
+
+    // 3. Change the stock quantity
+    const qtyField = page.locator('input[name="quantity_and_stock_status[qty]"]');
+    if (await qtyField.isVisible()) {
+      const currentQty = await qtyField.inputValue();
+      const newQty = String(parseInt(currentQty || '100', 10) + 1);
+      await qtyField.fill(newQty);
+    }
+
+    // 4. Save the product
+    await page.click('#save-button');
+    await page.waitForLoadState('networkidle');
+
+    // 5. Verify save succeeded — should see success message, not an error
+    const successMessage = page.locator('.message-success');
+    const errorMessage = page.locator('.message-error');
+
+    await expect(successMessage).toBeVisible({ timeout: 30000 });
+
+    // Ensure no constraint violation error appeared
+    const hasError = await errorMessage.count();
+    if (hasError > 0) {
+      const errorText = await errorMessage.first().textContent();
+      expect(errorText).not.toContain('constraint');
+      expect(errorText).not.toContain('item_id');
+    }
+
+    // 6. Verify the channable_items row was flagged for update (needs_update = 1)
+    //    and NOT corrupted by the id mismatch
+    const after = api['db']!.query(`
+      $stmt = $pdo->prepare("SELECT needs_update, item_id, id FROM channable_items WHERE item_id = ?");
+      $stmt->execute(['${ITEM_ID}']);
+      $row = $stmt->fetch(PDO::FETCH_ASSOC);
+      echo json_encode($row ?: 'not_found');
+    `);
+    const afterData = JSON.parse(after.trim());
+    expect(afterData).not.toBe('not_found');
+    expect(String(afterData.item_id)).toBe(ITEM_ID);
+    expect(String(afterData.id)).toBe(String(PRODUCT_ID));
+    expect(String(afterData.needs_update)).toBe('1');
+  });
+});

--- a/Test/End-2-end/tests/order/order-import.spec.ts
+++ b/Test/End-2-end/tests/order/order-import.spec.ts
@@ -13,6 +13,9 @@ const orderViewPage = new OrderViewPage();
 const customerViewPage = new CustomerViewPage();
 
 const PRODUCT_ID = parseInt(process.env.PRODUCT_ID || '1', 10);
+const SECOND_STORE_CODE = 'second_store';
+
+let secondStoreId: number | null = null;
 
 const CONFIG_BASE = 'magmodules_channable_marketplace/order';
 
@@ -210,11 +213,29 @@ const testCases = [
       expect(baseCurrencyTotal).toBeGreaterThan(0);
     },
   },
+  {
+    title: 'Customer created in correct store view',
+    config: {
+      [`${CONFIG_BASE}/import_customer`]: '1',
+    },
+    orderOverrides: {
+      email: `e2e-storeview-${Date.now()}@magmodules.eu`,
+    },
+    secondStore: true,
+    skipOrderView: true,
+    setup: async () => {
+      secondStoreId = channableApi.ensureSecondStoreView(SECOND_STORE_CODE);
+    },
+    assert: async (page, incrementId, orderData, baseURL) => {
+      const customer = await channableApi.getCustomerByEmail(baseURL, orderData.customer.email);
+      expect(customer.store_id).toBe(secondStoreId);
+    },
+  },
 ];
 
 for (const testCase of testCases) {
   test(`Order import: ${testCase.title}`, async ({ page, baseURL }) => {
-    // 0. Run optional setup (e.g. currency rates)
+    // 0. Run optional setup (e.g. currency rates, store views)
     if (testCase.setup) {
       await testCase.setup();
     }
@@ -231,14 +252,20 @@ for (const testCase of testCases) {
       ...testCase.orderOverrides,
     });
 
-    const response = await channableApi.postOrder(baseURL, orderData);
+    let storeId = 1;
+    if (testCase.secondStore && secondStoreId) {
+      storeId = secondStoreId;
+    }
+    const response = await channableApi.postOrder(baseURL, orderData, storeId);
     const incrementId = getOrderIncrementId(response);
     console.log(`Order created: ${incrementId} (${testCase.title})`);
 
-    // 3. Open order in admin
-    await orderViewPage.openByIncrementId(page, incrementId);
+    // 3. Open order in admin (skip for tests that only need API assertions)
+    if (!testCase.skipOrderView) {
+      await orderViewPage.openByIncrementId(page, incrementId);
+    }
 
     // 4. Run test-specific assertions
-    await testCase.assert(page, incrementId);
+    await testCase.assert(page, incrementId, orderData, baseURL);
   });
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "magmodules/magento2-channable",
     "description": "Channable integration for Magento 2",
     "type": "magento2-module",
-    "version": "1.24.1",
+    "version": "1.24.2",
     "license": "BSD-2-Clause",
     "homepage": "https://github.com/magmodules/magento2-channable",
     "require": {

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,7 +12,7 @@
             <general>
                 <enable>0</enable>
                 <limit>250</limit>
-                <version>v1.24.1</version>
+                <version>v1.24.2</version>
             </general>
             <data>
                 <name_attribute>name</name_attribute>


### PR DESCRIPTION
**Bugfixes:**
* Fixed `item_id`/`id` column mismatch causing constraint violations when observers trigger item saves.
* Fixed bundle product pricing in feed by using indexed prices instead of `getBaseAmount()`.
* Fixed customer being assigned to wrong store view on order import.
* Fixed credit memo creation being blocked for orders placed via the Channable payment method.
* Added early return guard for missing product ID in item add to prevent exceptions.

**Improvements:**
* Added PHP 8.5 / Magento 2.4.9 to setup-upgrade CI matrix.

**Minimum requirements:**
* Magento 2.3.x & 2.4.x
* PHP 7.4 to 8.5